### PR TITLE
Sanitize all parser

### DIFF
--- a/src/main/disk/AllLoader.cpp
+++ b/src/main/disk/AllLoader.cpp
@@ -65,7 +65,7 @@ vector<shared_ptr<mpc::sequencer::Sequence>> AllLoader::loadOnlySequencesFromFil
     auto allSequences = allParser.getAllSequences();
     
     auto allSeqNames = allParser.getSeqNames()->getNames();
-    vector<Sequence*> temp;
+    vector<AllSequence*> temp;
     int counter = 0;
 
     for (int i = 0; i < 99; i++)
@@ -100,7 +100,7 @@ void AllLoader::loadEverythingFromFile(mpc::Mpc& mpc, mpc::disk::MpcFile* f)
     AllLoader::loadEverythingFromAllParser(mpc, allParser);
 }
 
-void AllLoader::convertAllSeqToMpcSeq(mpc::file::all::Sequence* as, shared_ptr<mpc::sequencer::Sequence> mpcSeq)
+void AllLoader::convertAllSeqToMpcSeq(mpc::file::all::AllSequence* as, shared_ptr<mpc::sequencer::Sequence> mpcSeq)
 {
     mpcSeq->init(as->barCount - 1);
 

--- a/src/main/disk/AllLoader.cpp
+++ b/src/main/disk/AllLoader.cpp
@@ -55,37 +55,8 @@ using namespace mpc::lcdgui::screens::window;
 using namespace mpc::lcdgui::screens::dialog;
 using namespace mpc::disk;
 using namespace mpc::file::all;
+using namespace mpc::sequencer;
 using namespace std;
-
-vector<shared_ptr<mpc::sequencer::Sequence>> AllLoader::loadOnlySequencesFromFile(mpc::Mpc& mpc, mpc::disk::MpcFile* f)
-{
-	vector<shared_ptr<mpc::sequencer::Sequence>> mpcSequences;
-
-    AllParser allParser(mpc, f);
-    
-    auto allSequences = allParser.getAllSequences();
-    
-    auto allSeqNames = allParser.getSeqNames()->getNames();
-    vector<AllSequence*> temp;
-    int counter = 0;
-
-    for (int i = 0; i < 99; i++)
-    {
-        if (allSeqNames[i].find("(Unused)") != string::npos)
-        {
-            mpcSequences.push_back({});
-            continue;
-        }
-        
-        auto mpcSeq = make_shared<mpc::sequencer::Sequence>(mpc, mpc.getSequencer().lock()->getDefaultTrackNames());
-        
-        allSequences[counter++]->applyToMpcSeq(mpcSeq);
-        
-        mpcSequences.push_back(mpcSeq);
-    }
-    
-    return mpcSequences;
-}
 
 void AllLoader::loadEverythingFromFile(mpc::Mpc& mpc, mpc::disk::MpcFile* f)
 {
@@ -218,4 +189,33 @@ void AllLoader::loadEverythingFromAllParser(mpc::Mpc& mpc, AllParser& allParser)
 
     for (int i = 0; i < 20; i++)
         lSequencer->getSong(i).lock()->setName(songs[i]->name);
+}
+
+vector<shared_ptr<Sequence>> AllLoader::loadOnlySequencesFromFile(mpc::Mpc& mpc, mpc::disk::MpcFile* f)
+{
+    vector<shared_ptr<Sequence>> mpcSequences;
+
+    AllParser allParser(mpc, f);
+    
+    auto allSequences = allParser.getAllSequences();
+    
+    auto allSeqNames = allParser.getSeqNames()->getNames();
+    int counter = 0;
+
+    for (int i = 0; i < 99; i++)
+    {
+        if (allSeqNames[i].find("(Unused)") != string::npos)
+        {
+            mpcSequences.push_back({});
+            continue;
+        }
+        
+        auto mpcSeq = make_shared<Sequence>(mpc);
+        
+        allSequences[counter++]->applyToMpcSeq(mpcSeq);
+        
+        mpcSequences.push_back(mpcSeq);
+    }
+    
+    return mpcSequences;
 }

--- a/src/main/disk/AllLoader.cpp
+++ b/src/main/disk/AllLoader.cpp
@@ -61,7 +61,8 @@ vector<shared_ptr<mpc::sequencer::Sequence>> AllLoader::loadOnlySequencesFromFil
 {
 	vector<shared_ptr<mpc::sequencer::Sequence>> mpcSequences;
 
-    auto allParser = AllParser(mpc, f);
+    AllParser allParser(mpc, f);
+    
     auto allSequences = allParser.getAllSequences();
     
     auto allSeqNames = allParser.getSeqNames()->getNames();
@@ -71,26 +72,18 @@ vector<shared_ptr<mpc::sequencer::Sequence>> AllLoader::loadOnlySequencesFromFil
     for (int i = 0; i < 99; i++)
     {
         if (allSeqNames[i].find("(Unused)") != string::npos)
-            temp.push_back(nullptr);
-        else
-            temp.push_back(allSequences[counter++]);
-    }
-
-    allSequences = temp;
-
-    for (auto& as : allSequences)
-    {
-        if (as == nullptr)
         {
-            mpcSequences.push_back(nullptr);
+            mpcSequences.push_back({});
             continue;
         }
-
+        
         auto mpcSeq = make_shared<mpc::sequencer::Sequence>(mpc, mpc.getSequencer().lock()->getDefaultTrackNames());
-        convertAllSeqToMpcSeq(as, mpcSeq);
+        
+        convertAllSeqToMpcSeq(allSequences[counter++], mpcSeq);
+        
         mpcSequences.push_back(mpcSeq);
     }
-
+    
     return mpcSequences;
 }
 

--- a/src/main/disk/AllLoader.hpp
+++ b/src/main/disk/AllLoader.hpp
@@ -7,28 +7,25 @@ namespace mpc { class Mpc; }
 
 namespace mpc::disk
 {
-	class MpcFile;
+class MpcFile;
 }
 
 namespace mpc::file::all {
-	class AllParser;
-	class AllSequence;
+class AllParser;
+class AllSequence;
 }
 
 namespace mpc::sequencer
 {
-	class Sequence;
+class Sequence;
 }
 
 namespace mpc::disk {
-	class AllLoader
-	{
-	public:
-		static std::vector<std::shared_ptr<mpc::sequencer::Sequence>> loadOnlySequencesFromFile(mpc::Mpc&, mpc::disk::MpcFile*);
-		static void loadEverythingFromFile(mpc::Mpc&, mpc::disk::MpcFile*);
-		static void loadEverythingFromAllParser(mpc::Mpc&, mpc::file::all::AllParser&);
-
-	private:
-		static void convertAllSeqToMpcSeq(mpc::file::all::AllSequence*, std::shared_ptr<mpc::sequencer::Sequence>);
-	};
+class AllLoader
+{
+public:
+    static std::vector<std::shared_ptr<mpc::sequencer::Sequence>> loadOnlySequencesFromFile(mpc::Mpc&, mpc::disk::MpcFile*);
+    static void loadEverythingFromFile(mpc::Mpc&, mpc::disk::MpcFile*);
+    static void loadEverythingFromAllParser(mpc::Mpc&, mpc::file::all::AllParser&);
+};
 }

--- a/src/main/disk/AllLoader.hpp
+++ b/src/main/disk/AllLoader.hpp
@@ -24,8 +24,9 @@ namespace mpc::disk {
 class AllLoader
 {
 public:
-    static std::vector<std::shared_ptr<mpc::sequencer::Sequence>> loadOnlySequencesFromFile(mpc::Mpc&, mpc::disk::MpcFile*);
     static void loadEverythingFromFile(mpc::Mpc&, mpc::disk::MpcFile*);
     static void loadEverythingFromAllParser(mpc::Mpc&, mpc::file::all::AllParser&);
+    static std::vector<std::shared_ptr<mpc::sequencer::Sequence>> loadOnlySequencesFromFile(mpc::Mpc&, mpc::disk::MpcFile*);
+
 };
 }

--- a/src/main/disk/AllLoader.hpp
+++ b/src/main/disk/AllLoader.hpp
@@ -12,7 +12,7 @@ namespace mpc::disk
 
 namespace mpc::file::all {
 	class AllParser;
-	class Sequence;
+	class AllSequence;
 }
 
 namespace mpc::sequencer
@@ -29,6 +29,6 @@ namespace mpc::disk {
 		static void loadEverythingFromAllParser(mpc::Mpc&, mpc::file::all::AllParser&);
 
 	private:
-		static void convertAllSeqToMpcSeq(mpc::file::all::Sequence*, std::shared_ptr<mpc::sequencer::Sequence>);
+		static void convertAllSeqToMpcSeq(mpc::file::all::AllSequence*, std::shared_ptr<mpc::sequencer::Sequence>);
 	};
 }

--- a/src/main/disk/SoundLoader.cpp
+++ b/src/main/disk/SoundLoader.cpp
@@ -45,9 +45,7 @@ int SoundLoader::loadSound(weak_ptr<MpcFile> f)
 
 	auto soundFile = f.lock();
 	string soundFileName = soundFile->getName();
-    
-    MLOG("Loading sound file " + soundFileName);
-    
+        
 	auto periodIndex = soundFileName.find_last_of('.');
 	string extension = "";
 	string soundName = "";
@@ -143,7 +141,7 @@ int SoundLoader::loadSound(weak_ptr<MpcFile> f)
 	else if (StrUtil::eqIgnoreCase(extension, "snd"))
 	{
 		auto sndReader = mpc::file::sndreader::SndReader(soundFile.get());
-		sndReader.getSampleData(fa);
+		sndReader.writeSampleData(fa);
 		size = fa->size();
 		mono = sndReader.isMono();
 		start = sndReader.getStart();
@@ -169,38 +167,35 @@ int SoundLoader::loadSound(weak_ptr<MpcFile> f)
 	sound->setBeatCount(beats);
 
 	bool alreadyLoaded = existingSoundIndex != -1;
-
-    MLOG("Loaded sound " + soundFileName);
     
 	if (preview)
 	{
 		return existingSoundIndex;
 	}
-	else
-	{
-		if (existingSoundIndex == -1)
-		{
-			if (partOfProgram)
-				return (int)(sampler->getSoundCount()) - 1;
-		}
-		else
-		{
-			if (replace)
-			{
-				sampler->deleteSound(existingSoundIndex);
-				sound->setMemoryIndex(existingSoundIndex);
-				sampler->sort();
-			}
-			else
-			{
-				sampler->deleteSound((int)(sampler->getSoundCount()) - 1);
-			}
-			
-			if (partOfProgram)
-				return existingSoundIndex;
-		}
-	}
-	return -1;
+
+    if (existingSoundIndex == -1)
+    {
+        if (partOfProgram)
+            return (int)(sampler->getSoundCount()) - 1;
+    }
+    else
+    {
+        if (replace)
+        {
+            sampler->deleteSound(existingSoundIndex);
+            sound->setMemoryIndex(existingSoundIndex);
+            sampler->sort();
+        }
+        else
+        {
+            sampler->deleteSound((int)(sampler->getSoundCount()) - 1);
+        }
+        
+        if (partOfProgram)
+            return existingSoundIndex;
+    }
+
+    return -1;
 }
 
 void SoundLoader::getSampleDataFromWav(weak_ptr<moduru::file::File> soundFile, vector<float>* dest)

--- a/src/main/file/all/AllChannelPressureEvent.cpp
+++ b/src/main/file/all/AllChannelPressureEvent.cpp
@@ -2,28 +2,30 @@
 
 #include <file/all/AllEvent.hpp>
 #include <sequencer/ChannelPressureEvent.hpp>
-#include <sequencer/Event.hpp>
 
 using namespace mpc::file::all;
+using namespace mpc::sequencer;
 using namespace std;
 
-AllChannelPressureEvent::AllChannelPressureEvent(const vector<char>& ba) 
+shared_ptr<ChannelPressureEvent> AllChannelPressureEvent::bytesToMpcEvent(const std::vector<char>& bytes)
 {
-	auto cpe = new mpc::sequencer::ChannelPressureEvent();
-	cpe->setTick(AllEvent::readTick(ba));
-	cpe->setTrack(ba[AllEvent::TRACK_OFFSET]);
-	cpe->setAmount(ba[AMOUNT_OFFSET]);
-	event = cpe;
+    auto event = make_shared<ChannelPressureEvent>();
+    
+    event->setTick(AllEvent::readTick(bytes));
+    event->setTrack(bytes[AllEvent::TRACK_OFFSET]);
+    event->setAmount(bytes[AMOUNT_OFFSET]);
+    
+    return event;
 }
 
-AllChannelPressureEvent::AllChannelPressureEvent(mpc::sequencer::Event* e) 
+vector<char> AllChannelPressureEvent::mpcEventToBytes(shared_ptr<ChannelPressureEvent> event)
 {
-	auto cpe = dynamic_cast< mpc::sequencer::ChannelPressureEvent* >(e);
-	saveBytes = vector<char>(8);
-	saveBytes[AllEvent::EVENT_ID_OFFSET] = AllEvent::CH_PRESSURE_ID;
-	AllEvent::writeTick(saveBytes, static_cast< int >(e->getTick()));
-	saveBytes[AllEvent::TRACK_OFFSET] = static_cast< int8_t >(e->getTrack());
-	saveBytes[AMOUNT_OFFSET] = static_cast< int8_t >(cpe->getAmount());
+    vector<char> bytes(8);
+    
+    bytes[AllEvent::EVENT_ID_OFFSET] = AllEvent::CH_PRESSURE_ID;
+    AllEvent::writeTick(bytes, static_cast<int>(event->getTick()));
+    bytes[AllEvent::TRACK_OFFSET] = static_cast<int8_t>(event->getTrack());
+    bytes[AMOUNT_OFFSET] = static_cast<int8_t>(event->getAmount());
+    
+    return bytes;
 }
-
-int AllChannelPressureEvent::AMOUNT_OFFSET = 5;

--- a/src/main/file/all/AllChannelPressureEvent.hpp
+++ b/src/main/file/all/AllChannelPressureEvent.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 
 namespace mpc::sequencer {
-class Event;
+class ChannelPressureEvent;
 }
 
 namespace mpc::file::all {
@@ -11,14 +12,10 @@ class AllChannelPressureEvent
 {
     
 private:
-    static int AMOUNT_OFFSET;
-    
+    const static int AMOUNT_OFFSET = 5;
+        
 public:
-    mpc::sequencer::Event* event;
-    std::vector<char> saveBytes;
-    
-public:
-    AllChannelPressureEvent(const std::vector<char>& ba);
-    AllChannelPressureEvent(mpc::sequencer::Event* e);
+    static std::shared_ptr<mpc::sequencer::ChannelPressureEvent> bytesToMpcEvent(const std::vector<char>&);
+    static std::vector<char> mpcEventToBytes(std::shared_ptr<mpc::sequencer::ChannelPressureEvent>);
 };
 }

--- a/src/main/file/all/AllControlChangeEvent.cpp
+++ b/src/main/file/all/AllControlChangeEvent.cpp
@@ -5,28 +5,30 @@
 #include <sequencer/Event.hpp>
 
 using namespace mpc::file::all;
+using namespace mpc::sequencer;
 using namespace std;
 
-AllControlChangeEvent::AllControlChangeEvent(const vector<char>& ba) 
+shared_ptr<ControlChangeEvent> AllControlChangeEvent::bytesToMpcEvent(const vector<char>& bytes)
 {
-	auto cce = new mpc::sequencer::ControlChangeEvent();
-	cce->setTick(AllEvent::readTick(ba));
-	cce->setTrack(ba[AllEvent::TRACK_OFFSET]);
-	cce->setController(ba[CONTROLLER_OFFSET]);
-	cce->setAmount(ba[AMOUNT_OFFSET]);
-	event = cce;
+	auto event = make_shared<ControlChangeEvent>();
+	
+    event->setTick(AllEvent::readTick(bytes));
+	event->setTrack(bytes[AllEvent::TRACK_OFFSET]);
+	event->setController(bytes[CONTROLLER_OFFSET]);
+	event->setAmount(bytes[AMOUNT_OFFSET]);
+    
+    return event;
 }
 
-AllControlChangeEvent::AllControlChangeEvent(mpc::sequencer::Event* e) 
+vector<char> AllControlChangeEvent::mpcEventToBytes(shared_ptr<ControlChangeEvent> event)
 {
-	auto cce = dynamic_cast<mpc::sequencer::ControlChangeEvent*>(e);
-	saveBytes = vector<char>(8);
-	saveBytes[AllEvent::EVENT_ID_OFFSET] = AllEvent::CONTROL_CHANGE_ID;
-	AllEvent::writeTick(saveBytes, static_cast< int >(e->getTick()));
-	saveBytes[AllEvent::TRACK_OFFSET] = static_cast< int8_t >(e->getTrack());
-	saveBytes[CONTROLLER_OFFSET] = static_cast< int8_t >(cce->getController());
-	saveBytes[AMOUNT_OFFSET] = static_cast< int8_t >(cce->getAmount());
+	vector<char> bytes(8);
+    
+    bytes[AllEvent::EVENT_ID_OFFSET] = AllEvent::CONTROL_CHANGE_ID;
+	AllEvent::writeTick(bytes, static_cast<int>(event->getTick()));
+	bytes[AllEvent::TRACK_OFFSET] = static_cast<int8_t>(event->getTrack());
+	bytes[CONTROLLER_OFFSET] = static_cast<int8_t>(event->getController());
+	bytes[AMOUNT_OFFSET] = static_cast<int8_t>(event->getAmount());
+    
+    return bytes;
 }
-
-int AllControlChangeEvent::CONTROLLER_OFFSET = 5;
-int AllControlChangeEvent::AMOUNT_OFFSET = 6;

--- a/src/main/file/all/AllControlChangeEvent.hpp
+++ b/src/main/file/all/AllControlChangeEvent.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 
 namespace mpc::sequencer {
-class Event;
+class ControlChangeEvent;
 }
 
 namespace mpc::file::all {
@@ -12,15 +13,12 @@ class AllControlChangeEvent
 {
     
 private:
-    static int CONTROLLER_OFFSET;
-    static int AMOUNT_OFFSET;
-    
+    const static int CONTROLLER_OFFSET = 5;
+    const static int AMOUNT_OFFSET = 6;
+
 public:
-    mpc::sequencer::Event* event;
-    std::vector<char> saveBytes;
-    
-public:
-    AllControlChangeEvent(const std::vector<char>& ba);
-    AllControlChangeEvent(mpc::sequencer::Event* e);
+    static std::shared_ptr<mpc::sequencer::ControlChangeEvent> bytesToMpcEvent(const std::vector<char>&);
+    static std::vector<char> mpcEventToBytes(std::shared_ptr<mpc::sequencer::ControlChangeEvent>);
+
 };
 }

--- a/src/main/file/all/AllEvent.hpp
+++ b/src/main/file/all/AllEvent.hpp
@@ -11,31 +11,28 @@ class AllEvent
 {
     
 public:
-    static const int TICK_BYTE1_OFFSET{ 0 };
-    static const int TICK_BYTE2_OFFSET{ 1 };
-    static const int TICK_BYTE3_OFFSET{ 2 };
+    static const int TICK_BYTE1_OFFSET = 0;
+    static const int TICK_BYTE2_OFFSET = 1;
+    static const int TICK_BYTE3_OFFSET = 2;
     static std::vector<int> TICK_BYTE3_BIT_RANGE;
     
 public:
-    static const int TRACK_OFFSET{ 3 };
-    static const int EVENT_ID_OFFSET{ 4 };
+    static const int TRACK_OFFSET = 3;
+    static const int EVENT_ID_OFFSET = 4;
+    
     static const char POLY_PRESSURE_ID = 0xA0;
     static const char CONTROL_CHANGE_ID = 0xB0;
     static const char PGM_CHANGE_ID = 0xC0;
     static const char CH_PRESSURE_ID = 0xD0;
     static const char PITCH_BEND_ID = 0xE0;
     static const char SYS_EX_ID = 0xF0;
-    mpc::sequencer::Event* event;
-    std::vector<char> bytes;
     
 public:
-    virtual mpc::sequencer::Event* getEvent();
-    std::vector<char> getBytes();
-    static int readTick(const std::vector<char>& b);
-    static std::vector<char> writeTick(std::vector<char> event, int tick);
+    static int readTick(const std::vector<char>&);
+    static void writeTick(std::vector<char>&, int);
     
-    AllEvent(const std::vector<char>& ba);
-    AllEvent(mpc::sequencer::Event* event);
+    static std::shared_ptr<mpc::sequencer::Event> bytesToMpcEvent(const std::vector<char>&);
+    static std::vector<char> mpcEventToBytes(std::shared_ptr<mpc::sequencer::Event>);
     
 };
 }

--- a/src/main/file/all/AllNoteEvent.cpp
+++ b/src/main/file/all/AllNoteEvent.cpp
@@ -19,8 +19,9 @@ shared_ptr<NoteEvent> AllNoteEvent::bytesToMpcEvent(const vector<char>& bytes)
     
     event->setNote(bytes[NOTE_NUMBER_OFFSET]);
     event->setTick(AllEvent::readTick(bytes));
-    event->setTrack(readTrackNumber(bytes));
-    event->setDuration(readDuration(bytes));
+    auto track = readTrackNumber(bytes);
+    event->setTrack(track);
+    event->setDuration(readDuration(bytes)- (track * 4));
     event->setVelocity(readVelocity(bytes));
     event->setVariationTypeNumber(readVariationType(bytes));
     event->setVariationValue(readVariationValue(bytes));

--- a/src/main/file/all/AllNoteEvent.cpp
+++ b/src/main/file/all/AllNoteEvent.cpp
@@ -1,214 +1,182 @@
-#include <file/all/AllNoteEvent.hpp>
+#include "AllNoteEvent.hpp"
 
-#include <file/BitUtil.hpp>
-#include <file/all/AllEvent.hpp>
-#include <file/all/AllSequence.hpp>
+#include "AllEvent.hpp"
+#include "AllSequence.hpp"
+
 #include <sequencer/Event.hpp>
 #include <sequencer/NoteEvent.hpp>
 
-using namespace std;
-using namespace mpc::file::all;
+#include <file/BitUtil.hpp>
 
-AllNoteEvent::AllNoteEvent(const vector<char>& b) 
+using namespace mpc::file::all;
+using namespace mpc::sequencer;
+using namespace moduru::file;
+using namespace std;
+
+shared_ptr<NoteEvent> AllNoteEvent::bytesToMpcEvent(const vector<char>& bytes)
 {
-	note = b[NOTE_NUMBER_OFFSET];
-	tick = AllEvent::readTick(b);
-	track = readTrackNumber(b);
-	duration = readDuration(b) - (track * 4);
-	velocity = readVelocity(b);
-	variationValue = readVariationValue(b);
-	variationType = readVariationType(b);
+    auto event = make_shared<NoteEvent>();
+    
+    event->setNote(bytes[NOTE_NUMBER_OFFSET]);
+    event->setTick(AllEvent::readTick(bytes));
+    event->setTrack(readTrackNumber(bytes));
+    event->setDuration(readDuration(bytes));
+    event->setVelocity(readVelocity(bytes));
+    event->setVariationTypeNumber(readVariationType(bytes));
+    event->setVariationValue(readVariationValue(bytes));
+    
+    return event;
 }
 
-AllNoteEvent::AllNoteEvent(mpc::sequencer::Event* event)
+vector<char> AllNoteEvent::mpcEventToBytes(std::shared_ptr<NoteEvent> event)
 {
-	saveBytes = vector<char>(Sequence::EVENT_SEG_LENGTH);
-	auto ne = dynamic_cast<sequencer::NoteEvent*>(event);
-    
-	saveBytes[NOTE_NUMBER_OFFSET] = static_cast<int8_t>(ne->getNote());
+    vector<char> bytes(AllSequence::EVENT_SEG_LENGTH);
+	
+	bytes[NOTE_NUMBER_OFFSET] = static_cast<int8_t>(event->getNote());
 	
     try {
-		saveBytes = setVelocity(saveBytes, ne->getVelocity());
-		saveBytes = setTrackNumber(saveBytes, ne->getTrack());
-		saveBytes = setVariationType(saveBytes, ne->getVariationType());
-		saveBytes = setVariationValue(saveBytes, ne->getVariationValue());
-		saveBytes = AllEvent::writeTick(saveBytes, static_cast<int>(ne->getTick()));
-		saveBytes = setDuration(saveBytes, static_cast<int>(ne->getDuration()));
+		writeVelocity(bytes, event->getVelocity());
+		writeTrackNumber(bytes, event->getTrack());
+		writeVariationType(bytes, event->getVariationType());
+		writeVariationValue(bytes, event->getVariationValue());
+		AllEvent::writeTick(bytes, static_cast<int>(event->getTick()));
+		writeDuration(bytes, static_cast<int>(event->getDuration()));
 	}
 	catch (exception e) {
 		throw e;
 	}
+    
+    return bytes;
 }
 
-const int AllNoteEvent::DURATION_BYTE1_OFFSET;
 vector<int> AllNoteEvent::DURATION_BYTE1_BIT_RANGE = vector<int>{ 4, 7 };
-const int AllNoteEvent::DURATION_BYTE2_OFFSET;
 vector<int> AllNoteEvent::DURATION_BYTE2_BIT_RANGE = vector<int>{ 6, 7 };
-const int AllNoteEvent::TRACK_NUMBER_OFFSET;
 vector<int> AllNoteEvent::TRACK_NUMBER_BIT_RANGE = vector<int>{ 0, 5 };
-const int AllNoteEvent::NOTE_NUMBER_OFFSET;
-const int AllNoteEvent::DURATION_BYTE3_OFFSET;
-const int AllNoteEvent::VELOCITY_OFFSET;
 vector<int> AllNoteEvent::VELOCITY_BIT_RANGE = vector<int>{ 0, 6 };
-const int AllNoteEvent::VAR_TYPE_BYTE1_OFFSET;
-const int AllNoteEvent::VAR_TYPE_BYTE1_BIT;
-const int AllNoteEvent::VAR_TYPE_BYTE2_OFFSET;
-const int AllNoteEvent::VAR_TYPE_BYTE2_BIT;
-const int AllNoteEvent::VAR_VALUE_OFFSET;
 vector<int> AllNoteEvent::VAR_VALUE_BIT_RANGE = vector<int>{ 0, 6 };
 
-int AllNoteEvent::getNote()
+int AllNoteEvent::readDuration(const vector<char>& bytes)
 {
-    return note;
-}
-
-int AllNoteEvent::getTick()
-{
-    return tick;
-}
-
-int AllNoteEvent::getDuration()
-{
-    return duration;
-}
-
-int AllNoteEvent::getTrack()
-{
-    return track;
-}
-
-int AllNoteEvent::getVelocity()
-{
-    return velocity;
-}
-
-int AllNoteEvent::getVariationType()
-{
-    return variationType;
-}
-
-int AllNoteEvent::getVariationValue()
-{
-    return variationValue;
-}
-
-int AllNoteEvent::readDuration(vector<char> b)
-{
-    auto b1 = b[DURATION_BYTE1_OFFSET];
-    auto b2 = b[DURATION_BYTE2_OFFSET];
-    auto b3 = b[DURATION_BYTE3_OFFSET];
-    if (static_cast<unsigned char>(b1) == 255 && static_cast<unsigned char>(b2) == 255 && static_cast<unsigned char>(b3) == 255) {
+    auto b1 = bytes[DURATION_BYTE1_OFFSET];
+    auto b2 = bytes[DURATION_BYTE2_OFFSET];
+    auto b3 = bytes[DURATION_BYTE3_OFFSET];
+    
+    if (static_cast<unsigned char>(b1) == 255 && static_cast<unsigned char>(b2) == 255 && static_cast<unsigned char>(b3) == 255)
+    {
         return -1;
     }
 
-    b1 = moduru::file::BitUtil::removeUnusedBits(b1, DURATION_BYTE1_BIT_RANGE);
-    b2 = moduru::file::BitUtil::removeUnusedBits(b2, DURATION_BYTE2_BIT_RANGE);
+    b1 = BitUtil::removeUnusedBits(b1, DURATION_BYTE1_BIT_RANGE);
+    b2 = BitUtil::removeUnusedBits(b2, DURATION_BYTE2_BIT_RANGE);
+    
     auto i1 = static_cast<int>(b1 & 255);
     auto i2 = static_cast<int>(b2 & 255);
     auto i3 = static_cast<int>(b3 & 255);
+    
     return (i1 << 6) + (i2 << 2) + i3;
 }
 
-int AllNoteEvent::readTrackNumber(vector<char> ba)
+int AllNoteEvent::readTrackNumber(const vector<char>& bytes)
 {
-    auto b = moduru::file::BitUtil::removeUnusedBits(ba[TRACK_NUMBER_OFFSET], TRACK_NUMBER_BIT_RANGE);
+    auto b = BitUtil::removeUnusedBits(bytes[TRACK_NUMBER_OFFSET], TRACK_NUMBER_BIT_RANGE);
     return b;
 }
 
-int AllNoteEvent::readVelocity(vector<char> ba)
+int AllNoteEvent::readVelocity(const vector<char>& bytes)
 {
-    auto b = moduru::file::BitUtil::removeUnusedBits(ba[VELOCITY_OFFSET], VELOCITY_BIT_RANGE);
+    auto b = BitUtil::removeUnusedBits(bytes[VELOCITY_OFFSET], VELOCITY_BIT_RANGE);
     return b;
 }
 
-int AllNoteEvent::readVariationValue(vector<char> ba)
+int AllNoteEvent::readVariationValue(const vector<char>& bytes)
 {
-    auto b = moduru::file::BitUtil::removeUnusedBits(ba[VAR_VALUE_OFFSET], VAR_VALUE_BIT_RANGE);
+    auto b = BitUtil::removeUnusedBits(bytes[VAR_VALUE_OFFSET], VAR_VALUE_BIT_RANGE);
     return b;
 }
 
-int AllNoteEvent::readVariationType(vector<char> ba)
+int AllNoteEvent::readVariationType(const vector<char>& bytes)
 {
-    auto byte1 = ba[VAR_TYPE_BYTE1_OFFSET];
-    auto byte2 = ba[VAR_TYPE_BYTE2_OFFSET];
-    auto b1 = moduru::file::BitUtil::isBitOn(byte1, VAR_TYPE_BYTE1_BIT);
-    auto b2 = moduru::file::BitUtil::isBitOn(byte2, VAR_TYPE_BYTE2_BIT);
-    if(b1 && b2)
+    auto byte1 = bytes[VAR_TYPE_BYTE1_OFFSET];
+    auto byte2 = bytes[VAR_TYPE_BYTE2_OFFSET];
+    
+    auto b1 = BitUtil::isBitOn(byte1, VAR_TYPE_BYTE1_BIT);
+    auto b2 = BitUtil::isBitOn(byte2, VAR_TYPE_BYTE2_BIT);
+ 
+    if (b1 && b2)
         return 3;
 
-    if(b1 && !b2)
+    if (b1 && !b2)
         return 2;
 
-    if(!b1 && b2)
+    if (!b1 && b2)
         return 1;
 
-    if(!b1 && !b2)
+    if (!b1 && !b2)
         return 0;
 
     return -1;
 }
 
-vector<char> AllNoteEvent::setVelocity(vector<char> event, int v)
+void AllNoteEvent::writeVelocity(vector<char>& event, int v)
 {
     auto value = static_cast< int8_t >(v);
-    event[VELOCITY_OFFSET] = moduru::file::BitUtil::stitchBytes(event[VELOCITY_OFFSET], vector<int>{ VAR_TYPE_BYTE1_BIT, VAR_TYPE_BYTE1_BIT }, value, VELOCITY_BIT_RANGE);
+    event[VELOCITY_OFFSET] = BitUtil::stitchBytes(event[VELOCITY_OFFSET], vector<int>{ VAR_TYPE_BYTE1_BIT, VAR_TYPE_BYTE1_BIT }, value, VELOCITY_BIT_RANGE);
     return event;
 }
 
-vector<char> AllNoteEvent::setTrackNumber(vector<char> event, int t)
+void AllNoteEvent::writeTrackNumber(vector<char>& event, int t)
 {
     auto value = static_cast< int8_t >(t);
-    event[TRACK_NUMBER_OFFSET] = moduru::file::BitUtil::stitchBytes(event[TRACK_NUMBER_OFFSET], DURATION_BYTE2_BIT_RANGE, value, TRACK_NUMBER_BIT_RANGE);
+    event[TRACK_NUMBER_OFFSET] = BitUtil::stitchBytes(event[TRACK_NUMBER_OFFSET], DURATION_BYTE2_BIT_RANGE, value, TRACK_NUMBER_BIT_RANGE);
     return event;
 }
 
-vector<char> AllNoteEvent::setVariationValue(vector<char> event, int v)
+void AllNoteEvent::writeVariationValue(vector<char>& event, int v)
 {
     auto value = static_cast< int8_t >(v);
-    event[VAR_VALUE_OFFSET] = moduru::file::BitUtil::stitchBytes(event[VAR_VALUE_OFFSET], vector<int>{ VAR_TYPE_BYTE2_BIT, VAR_TYPE_BYTE2_BIT }, value, VAR_VALUE_BIT_RANGE);
+    event[VAR_VALUE_OFFSET] = BitUtil::stitchBytes(event[VAR_VALUE_OFFSET], vector<int>{ VAR_TYPE_BYTE2_BIT, VAR_TYPE_BYTE2_BIT }, value, VAR_VALUE_BIT_RANGE);
     return event;
 }
 
-vector<char> AllNoteEvent::setDuration(vector<char> event, int duration)
+void AllNoteEvent::writeDuration(vector<char>& event, int duration)
 {
     auto s1 = static_cast< short >(duration >> 6);
     auto s2 = static_cast< short >(duration >> 2);
     auto s3 = static_cast< short >(duration & 255);
-    event[DURATION_BYTE1_OFFSET] = moduru::file::BitUtil::stitchBytes(event[DURATION_BYTE1_OFFSET], AllEvent::TICK_BYTE3_BIT_RANGE, static_cast< int8_t >(s1), DURATION_BYTE1_BIT_RANGE);
-    event[DURATION_BYTE2_OFFSET] = moduru::file::BitUtil::stitchBytes(event[DURATION_BYTE2_OFFSET], TRACK_NUMBER_BIT_RANGE, static_cast< int8_t >(s2), DURATION_BYTE2_BIT_RANGE);
+    
+    event[DURATION_BYTE1_OFFSET] = BitUtil::stitchBytes(event[DURATION_BYTE1_OFFSET], AllEvent::TICK_BYTE3_BIT_RANGE, static_cast< int8_t >(s1), DURATION_BYTE1_BIT_RANGE);
+    
+    event[DURATION_BYTE2_OFFSET] = BitUtil::stitchBytes(event[DURATION_BYTE2_OFFSET], TRACK_NUMBER_BIT_RANGE, static_cast< int8_t >(s2), DURATION_BYTE2_BIT_RANGE);
+
     event[DURATION_BYTE3_OFFSET] = static_cast< int8_t >(s3);
+
     return event;
 }
 
-vector<char> AllNoteEvent::setVariationType(vector<char> event, int type)
+void AllNoteEvent::writeVariationType(vector<char>& event, int type)
 {
     auto byte1 = event[VAR_TYPE_BYTE1_OFFSET];
     auto byte2 = event[VAR_TYPE_BYTE2_OFFSET];
     switch (type) {
     case 0:
-        moduru::file::BitUtil::setBit(byte1, VAR_TYPE_BYTE1_BIT, false);
-        moduru::file::BitUtil::setBit(byte2, VAR_TYPE_BYTE2_BIT, false);
+        BitUtil::setBit(byte1, VAR_TYPE_BYTE1_BIT, false);
+        BitUtil::setBit(byte2, VAR_TYPE_BYTE2_BIT, false);
         break;
     case 1:
-        moduru::file::BitUtil::setBit(byte1, VAR_TYPE_BYTE1_BIT, false);
-        moduru::file::BitUtil::setBit(byte2, VAR_TYPE_BYTE2_BIT, true);
+        BitUtil::setBit(byte1, VAR_TYPE_BYTE1_BIT, false);
+        BitUtil::setBit(byte2, VAR_TYPE_BYTE2_BIT, true);
         break;
     case 2:
-        moduru::file::BitUtil::setBit(byte1, VAR_TYPE_BYTE1_BIT, true);
-        moduru::file::BitUtil::setBit(byte2, VAR_TYPE_BYTE2_BIT, false);
+        BitUtil::setBit(byte1, VAR_TYPE_BYTE1_BIT, true);
+        BitUtil::setBit(byte2, VAR_TYPE_BYTE2_BIT, false);
         break;
     case 3:
-        moduru::file::BitUtil::setBit(byte1, VAR_TYPE_BYTE1_BIT, true);
-        moduru::file::BitUtil::setBit(byte2, VAR_TYPE_BYTE2_BIT, true);
+        BitUtil::setBit(byte1, VAR_TYPE_BYTE1_BIT, true);
+        BitUtil::setBit(byte2, VAR_TYPE_BYTE2_BIT, true);
         break;
     }
 
     event[VAR_TYPE_BYTE1_OFFSET] = byte1;
     event[VAR_TYPE_BYTE2_OFFSET] = byte2;
     return event;
-}
-
-vector<char> AllNoteEvent::getBytes()
-{
-    return saveBytes;
 }

--- a/src/main/file/all/AllNoteEvent.hpp
+++ b/src/main/file/all/AllNoteEvent.hpp
@@ -1,68 +1,51 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 namespace mpc::sequencer {
-class Event;
+class NoteEvent;
 }
 
 namespace mpc::file::all {
+class AllEvent;
 class AllNoteEvent
 {
-    
-public:
-    static const int DURATION_BYTE1_OFFSET{ 2 };
+private:
+    static const int DURATION_BYTE1_OFFSET = 2;
     static std::vector<int> DURATION_BYTE1_BIT_RANGE;
-    static const int DURATION_BYTE2_OFFSET{ 3 };
+    static const int DURATION_BYTE2_OFFSET = 3;
     static std::vector<int> DURATION_BYTE2_BIT_RANGE;
-    static const int TRACK_NUMBER_OFFSET{ 3 };
+    static const int TRACK_NUMBER_OFFSET = 3;
     static std::vector<int> TRACK_NUMBER_BIT_RANGE;
-    static const int NOTE_NUMBER_OFFSET{ 4 };
-    static const int DURATION_BYTE3_OFFSET{ 5 };
-    static const int VELOCITY_OFFSET{ 6 };
+    static const int NOTE_NUMBER_OFFSET = 4;
+    static const int DURATION_BYTE3_OFFSET = 5;
+    static const int VELOCITY_OFFSET = 6;
     static std::vector<int> VELOCITY_BIT_RANGE;
-    static const int VAR_TYPE_BYTE1_OFFSET{ 6 };
-    static const int VAR_TYPE_BYTE1_BIT{ 7 };
-    static const int VAR_TYPE_BYTE2_OFFSET{ 7 };
-    static const int VAR_TYPE_BYTE2_BIT{ 7 };
-    static const int VAR_VALUE_OFFSET{ 7 };
+    static const int VAR_TYPE_BYTE1_OFFSET = 6;
+    static const int VAR_TYPE_BYTE1_BIT = 7;
+    static const int VAR_TYPE_BYTE2_OFFSET = 7;
+    static const int VAR_TYPE_BYTE2_BIT = 7;
+    static const int VAR_VALUE_OFFSET = 7;
     static std::vector<int> VAR_VALUE_BIT_RANGE;
     
-public:
-    int note{};
-    int tick{};
-    int duration{};
-    int track{};
-    int velocity{};
-    int variationType{};
-    int variationValue{};
-    std::vector<char> saveBytes{};
+    static int readDuration(const std::vector<char>&);
+    static int readTrackNumber(const std::vector<char>&);
+    static int readVelocity(const std::vector<char>&);
+    static int readVariationValue(const std::vector<char>&);
+    static int readVariationType(const std::vector<char>&);
+    
+    static void writeVelocity(std::vector<char>& event, int);
+    static void writeTrackNumber(std::vector<char>& event, int);
+    static void writeVariationValue(std::vector<char>& event, int);
+    static void writeDuration(std::vector<char>& event, int);
+    static void writeVariationType(std::vector<char>& event, int);
+    
+    friend class mpc::file::all::AllEvent;
     
 public:
-    int getNote();
-    int getTick();
-    int getDuration();
-    int getTrack();
-    int getVelocity();
-    int getVariationType();
-    int getVariationValue();
-    
-private:
-    int readDuration(std::vector<char> b);
-    int readTrackNumber(std::vector<char> ba);
-    int readVelocity(std::vector<char> ba);
-    int readVariationValue(std::vector<char> ba);
-    int readVariationType(std::vector<char> ba);
-    
-public:
-    std::vector<char> setVelocity(std::vector<char> event, int v);
-    std::vector<char> setTrackNumber(std::vector<char> event, int t);
-    std::vector<char> setVariationValue(std::vector<char> event, int v);
-    std::vector<char> setDuration(std::vector<char> event, int duration);
-    std::vector<char> setVariationType(std::vector<char> event, int type);
-    std::vector<char> getBytes();
-    
-    AllNoteEvent(const std::vector<char>& b);
-    AllNoteEvent(mpc::sequencer::Event* event);
+    static std::shared_ptr<mpc::sequencer::NoteEvent> bytesToMpcEvent(const std::vector<char>&);
+    static std::vector<char> mpcEventToBytes(std::shared_ptr<mpc::sequencer::NoteEvent>);
+
 };
 }

--- a/src/main/file/all/AllParser.cpp
+++ b/src/main/file/all/AllParser.cpp
@@ -123,25 +123,6 @@ AllParser::~AllParser()
 		if (s != nullptr) delete s;
 }
 
-const int AllParser::NAME_LENGTH;
-const int AllParser::DEV_NAME_LENGTH;
-const int AllParser::EMPTY_SEQ_LENGTH;
-const int AllParser::EVENT_LENGTH;
-const int AllParser::HEADER_OFFSET;
-const int AllParser::HEADER_LENGTH;
-const int AllParser::DEFAULTS_OFFSET;
-const int AllParser::DEFAULTS_LENGTH;
-const int AllParser::UNKNOWN1_OFFSET;
-const int AllParser::SEQUENCER_OFFSET;
-const int AllParser::COUNT_OFFSET;
-const int AllParser::COUNT_LENGTH;
-const int AllParser::MIDI_INPUT_OFFSET;
-const int AllParser::MIDI_SYNC_OFFSET;
-const int AllParser::MISC_OFFSET;
-const int AllParser::SEQUENCE_NAMES_OFFSET;
-const int AllParser::SONGS_OFFSET;
-const int AllParser::SEQUENCES_OFFSET;
-
 vector<AllSequence*> AllParser::getAllSequences()
 {
     return sequences;

--- a/src/main/file/all/AllParser.cpp
+++ b/src/main/file/all/AllParser.cpp
@@ -205,7 +205,7 @@ vector<AllSequence*> AllParser::readSequences(vector<char> trimmedSeqsArray)
 	return seqs;
 }
 
-vector<char> AllParser::getBytes()
+vector<char>& AllParser::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/AllParser.hpp
+++ b/src/main/file/all/AllParser.hpp
@@ -13,13 +13,13 @@ namespace mpc::disk {
 namespace mpc::file::all {
 	class Header;
 	class Defaults;
-	class Sequencer;
+	class AllSequencer;
 	class Count;
 	class MidiInput;
 	class MidiSyncMisc;
 	class Misc;
 	class SequenceNames;
-	class Sequence;
+	class AllSequence;
 	class Song;
 }
 
@@ -54,20 +54,20 @@ namespace mpc::file::all
 		static const int SEQUENCES_OFFSET{ 14406 };
 		Header* header = nullptr;
 		Defaults* defaults = nullptr;
-		Sequencer* sequencer = nullptr;
+		AllSequencer* sequencer = nullptr;
 		Count* count = nullptr;
 		MidiInput* midiInput = nullptr;
 		MidiSyncMisc* midiSyncMisc = nullptr;
 		Misc* misc = nullptr;
-		SequenceNames* seqNames = nullptr;
-		std::vector<Sequence*> sequences;
+        SequenceNames* seqNames = nullptr;
+        std::vector<AllSequence*> sequences;
         std::vector<Song*> songs = std::vector<Song*>(20);
 		std::vector<char> saveBytes;
 
 	public:
-		std::vector<Sequence*> getAllSequences();
+		std::vector<AllSequence*> getAllSequences();
 		Defaults* getDefaults();
-		Sequencer* getSequencer();
+		AllSequencer* getSequencer();
 		Count* getCount();
 		MidiInput* getMidiInput();
 		MidiSyncMisc* getMidiSync();
@@ -77,7 +77,9 @@ namespace mpc::file::all
 
 	private:
 		mpc::Mpc& mpc;
-		std::vector<Sequence*> readSequences(std::vector<char> trimmedSeqsArray);
+        
+        // Dangerous method, as the caller relies on the argument being a copy
+		std::vector<AllSequence*> readSequences(std::vector<char> trimmedSeqsArray);
 
 	public:
 		std::vector<char> getBytes();

--- a/src/main/file/all/AllParser.hpp
+++ b/src/main/file/all/AllParser.hpp
@@ -82,7 +82,7 @@ namespace mpc::file::all
 		std::vector<AllSequence*> readSequences(std::vector<char> trimmedSeqsArray);
 
 	public:
-		std::vector<char> getBytes();
+		std::vector<char>& getBytes();
 
 	public:
 		AllParser(mpc::Mpc&, mpc::disk::MpcFile*);

--- a/src/main/file/all/AllPitchBendEvent.cpp
+++ b/src/main/file/all/AllPitchBendEvent.cpp
@@ -2,43 +2,47 @@
 
 #include <Util.hpp>
 #include <file/all/AllEvent.hpp>
-#include <sequencer/Event.hpp>
 #include <sequencer/PitchBendEvent.hpp>
 
 #include <file/ByteUtil.hpp>
 
 using namespace mpc::file::all;
+using namespace mpc::sequencer;
+using namespace moduru::file;
 using namespace std;
 
-AllPitchBendEvent::AllPitchBendEvent(const vector<char>& ba)
+shared_ptr<PitchBendEvent> AllPitchBendEvent::bytesToMpcEvent(const vector<char>& bytes)
 {
-	auto pbe = new mpc::sequencer::PitchBendEvent();
-	pbe->setTick(AllEvent::readTick(ba));
-	pbe->setTrack(ba[AllEvent::TRACK_OFFSET]);
+	auto event = make_shared<PitchBendEvent>();
+	event->setTick(AllEvent::readTick(bytes));
+	event->setTrack(bytes[AllEvent::TRACK_OFFSET]);
 
-    auto candidate = moduru::file::ByteUtil::bytes2ushort(vector<char>{ ba[AMOUNT_OFFSET], ba[AMOUNT_OFFSET + 1] }) - 16384;
+    auto candidate = ByteUtil::bytes2ushort(vector<char>{ bytes[AMOUNT_OFFSET], bytes[AMOUNT_OFFSET + 1] }) - 16384;
 
     if (candidate < -8192)
 		candidate += 8192;
 
-	pbe->setAmount(candidate);
-	event = pbe;
+	event->setAmount(candidate);
+    
+    return event;
 }
 
-AllPitchBendEvent::AllPitchBendEvent(mpc::sequencer::Event* e) 
+vector<char> AllPitchBendEvent::mpcEventToBytes(shared_ptr<PitchBendEvent> event)
 {
-	auto pbe = dynamic_cast< mpc::sequencer::PitchBendEvent* >(e);
-	saveBytes = vector<char>(8);
-	saveBytes[AllEvent::EVENT_ID_OFFSET] = AllEvent::PITCH_BEND_ID;
-	AllEvent::writeTick(saveBytes, static_cast< int >(e->getTick()));
-	saveBytes[AllEvent::TRACK_OFFSET] = static_cast< int8_t >(e->getTrack());
-	auto candidate = pbe->getAmount() + 16384;
-	if (pbe->getAmount() < 0)
-		candidate = pbe->getAmount() + 8192;
+	vector<char> bytes(8);
+	bytes[AllEvent::EVENT_ID_OFFSET] = AllEvent::PITCH_BEND_ID;
+	AllEvent::writeTick(bytes, static_cast< int >(event->getTick()));
+	bytes[AllEvent::TRACK_OFFSET] = static_cast< int8_t >(event->getTrack());
+	
+    auto candidate = event->getAmount() + 16384;
+	
+    if (event->getAmount() < 0)
+		candidate = event->getAmount() + 8192;
 
-	auto amountBytes = moduru::file::ByteUtil::ushort2bytes(candidate);
-	saveBytes[AMOUNT_OFFSET] = amountBytes[0];
-	saveBytes[AMOUNT_OFFSET + 1] = amountBytes[1];
+	auto amountBytes = ByteUtil::ushort2bytes(candidate);
+	
+    bytes[AMOUNT_OFFSET] = amountBytes[0];
+	bytes[AMOUNT_OFFSET + 1] = amountBytes[1];
+    
+    return bytes;
 }
-
-int AllPitchBendEvent::AMOUNT_OFFSET = 5;

--- a/src/main/file/all/AllPitchBendEvent.hpp
+++ b/src/main/file/all/AllPitchBendEvent.hpp
@@ -1,31 +1,22 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 
-namespace mpc {
+namespace mpc::sequencer {
+class PitchBendEvent;
+}
 
-	namespace sequencer {
-		class Event;
-	}
+namespace mpc::file::all {
+class AllPitchBendEvent
+{
+    
+private:
+    const static int AMOUNT_OFFSET = 5;
+    
+public:
+    static std::shared_ptr<mpc::sequencer::PitchBendEvent> bytesToMpcEvent(const std::vector<char>&);
+    static std::vector<char> mpcEventToBytes(std::shared_ptr<mpc::sequencer::PitchBendEvent>);
 
-	namespace file {
-		namespace all {
-
-			class AllPitchBendEvent
-			{
-
-			private:
-				static int AMOUNT_OFFSET;
-
-			public:
-				mpc::sequencer::Event* event;
-				std::vector<char> saveBytes;
-
-			public:
-				AllPitchBendEvent(const std::vector<char>& ba);
-				AllPitchBendEvent(mpc::sequencer::Event* e);
-
-			};
-		}
-	}
+};
 }

--- a/src/main/file/all/AllPolyPressureEvent.cpp
+++ b/src/main/file/all/AllPolyPressureEvent.cpp
@@ -1,32 +1,33 @@
-#include <file/all/AllPolyPressureEvent.hpp>
+#include "AllPolyPressureEvent.hpp"
 
 #include <file/all/AllEvent.hpp>
-#include <sequencer/Event.hpp>
 #include <sequencer/PolyPressureEvent.hpp>
 
 using namespace mpc::file::all;
+using namespace mpc::sequencer;
 using namespace std;
 
-AllPolyPressureEvent::AllPolyPressureEvent(const vector<char>& ba) 
+shared_ptr<PolyPressureEvent> AllPolyPressureEvent::bytesToMpcEvent(const vector<char>& bytes)
 {
-	auto ppe = new mpc::sequencer::PolyPressureEvent();
-	ppe->setTick(AllEvent::readTick(ba));
-	ppe->setTrack(ba[AllEvent::TRACK_OFFSET]);
-	ppe->setNote(ba[NOTE_OFFSET]);
-	ppe->setAmount(ba[AMOUNT_OFFSET]);
-	event = ppe;
+	auto event = make_shared<PolyPressureEvent>();
+	
+    event->setTick(AllEvent::readTick(bytes));
+	event->setTrack(bytes[AllEvent::TRACK_OFFSET]);
+	event->setNote(bytes[NOTE_OFFSET]);
+	event->setAmount(bytes[AMOUNT_OFFSET]);
+	
+    return event;
 }
 
-AllPolyPressureEvent::AllPolyPressureEvent(mpc::sequencer::Event* e) 
+vector<char> AllPolyPressureEvent::mpcEventToBytes(shared_ptr<PolyPressureEvent> event)
 {
-	auto ppe = dynamic_cast< mpc::sequencer::PolyPressureEvent* >(e);
-	saveBytes = vector<char>(8);
-	saveBytes[AllEvent::EVENT_ID_OFFSET] = AllEvent::POLY_PRESSURE_ID;
-	AllEvent::writeTick(saveBytes, static_cast< int >(e->getTick()));
-	saveBytes[AllEvent::TRACK_OFFSET] = static_cast< int8_t >(e->getTrack());
-	saveBytes[NOTE_OFFSET] = static_cast< int8_t >(ppe->getNote());
-	saveBytes[AMOUNT_OFFSET] = static_cast< int8_t >(ppe->getAmount());
+	vector<char> bytes(8);
+	
+    bytes[AllEvent::EVENT_ID_OFFSET] = AllEvent::POLY_PRESSURE_ID;
+	AllEvent::writeTick(bytes, static_cast< int >(event->getTick()));
+	bytes[AllEvent::TRACK_OFFSET] = static_cast< int8_t >(event->getTrack());
+	bytes[NOTE_OFFSET] = static_cast< int8_t >(event->getNote());
+	bytes[AMOUNT_OFFSET] = static_cast< int8_t >(event->getAmount());
+    
+    return bytes;
 }
-
-int AllPolyPressureEvent::NOTE_OFFSET = 5;
-int AllPolyPressureEvent::AMOUNT_OFFSET = 6;

--- a/src/main/file/all/AllPolyPressureEvent.hpp
+++ b/src/main/file/all/AllPolyPressureEvent.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 namespace mpc::sequencer {
-class Event;
+class PolyPressureEvent;
 }
 
 namespace mpc::file::all {
@@ -12,15 +13,11 @@ class AllPolyPressureEvent
 {
     
 private:
-    static int NOTE_OFFSET;
-    static int AMOUNT_OFFSET;
+    const static int NOTE_OFFSET = 5;
+    const static int AMOUNT_OFFSET = 6;
     
 public:
-    mpc::sequencer::Event* event;
-    std::vector<char> saveBytes;
-    
-public:
-    AllPolyPressureEvent(const std::vector<char>& ba);
-    AllPolyPressureEvent(mpc::sequencer::Event* e);
+    static std::shared_ptr<mpc::sequencer::PolyPressureEvent> bytesToMpcEvent(const std::vector<char>&);
+    static std::vector<char> mpcEventToBytes(std::shared_ptr<mpc::sequencer::PolyPressureEvent>);
 };
 }

--- a/src/main/file/all/AllProgramChangeEvent.cpp
+++ b/src/main/file/all/AllProgramChangeEvent.cpp
@@ -1,29 +1,31 @@
-#include <file/all/AllProgramChangeEvent.hpp>
+#include "AllProgramChangeEvent.hpp"
 
 #include <file/all/AllEvent.hpp>
-#include <sequencer/Event.hpp>
 #include <sequencer/ProgramChangeEvent.hpp>
 
 using namespace mpc::file::all;
+using namespace mpc::sequencer;
 using namespace std;
 
-AllProgramChangeEvent::AllProgramChangeEvent(const vector<char>& ba) 
+shared_ptr<ProgramChangeEvent> AllProgramChangeEvent::bytesToMpcEvent(const vector<char>& bytes)
 {
-	auto pce = new mpc::sequencer::ProgramChangeEvent();
-	pce->setTick(AllEvent::readTick(ba));
-	pce->setTrack(ba[AllEvent::TRACK_OFFSET]);
-	pce->setProgram(ba[PROGRAM_OFFSET] + 1);
-	event = pce;
+	auto event = make_shared<ProgramChangeEvent>();
+	
+    event->setTick(AllEvent::readTick(bytes));
+	event->setTrack(bytes[AllEvent::TRACK_OFFSET]);
+	event->setProgram(bytes[PROGRAM_OFFSET] + 1);
+	
+    return event;
 }
 
-AllProgramChangeEvent::AllProgramChangeEvent(mpc::sequencer::Event* e) 
+vector<char> AllProgramChangeEvent::mpcEventToBytes(shared_ptr<ProgramChangeEvent> event)
 {
-	auto pce = dynamic_cast< mpc::sequencer::ProgramChangeEvent* >(e);
-	saveBytes = vector<char>(8);
-	saveBytes[AllEvent::EVENT_ID_OFFSET] = AllEvent::PGM_CHANGE_ID;
-	AllEvent::writeTick(saveBytes, static_cast< int >(e->getTick()));
-	saveBytes[AllEvent::TRACK_OFFSET] = static_cast< int8_t >(e->getTrack());
-	saveBytes[PROGRAM_OFFSET] = static_cast< int8_t >(pce->getProgram() - 1);
+	vector<char> bytes(8);
+    
+    bytes[AllEvent::EVENT_ID_OFFSET] = AllEvent::PGM_CHANGE_ID;
+	AllEvent::writeTick(bytes, static_cast<int>(event->getTick()));
+    bytes[AllEvent::TRACK_OFFSET] = static_cast<int8_t>(event->getTrack());
+    bytes[PROGRAM_OFFSET] = static_cast<int8_t>(event->getProgram() - 1);
+    
+    return bytes;
 }
-
-int AllProgramChangeEvent::PROGRAM_OFFSET = 5;

--- a/src/main/file/all/AllProgramChangeEvent.hpp
+++ b/src/main/file/all/AllProgramChangeEvent.hpp
@@ -2,30 +2,19 @@
 
 #include <vector>
 
-namespace mpc {
+namespace mpc::sequencer {
+class ProgramChangeEvent;
+}
 
-	namespace sequencer {
-		class Event;
-	}
-
-	namespace file {
-		namespace all {
-
-			class AllProgramChangeEvent
-			{
-
-			private:
-				static int PROGRAM_OFFSET;
-
-			public:
-				mpc::sequencer::Event* event {  };
-				std::vector<char> saveBytes{};
-
-			public:
-				AllProgramChangeEvent(const std::vector<char>& ba);
-				AllProgramChangeEvent(mpc::sequencer::Event* e);
-			};
-
-		}
-	}
+namespace mpc::file::all {
+class AllProgramChangeEvent
+{
+    
+private:
+    const static int PROGRAM_OFFSET = 5;
+    
+public:
+    static std::shared_ptr<mpc::sequencer::ProgramChangeEvent> bytesToMpcEvent(const std::vector<char>&);
+    static std::vector<char> mpcEventToBytes(std::shared_ptr<mpc::sequencer::ProgramChangeEvent>);
+};
 }

--- a/src/main/file/all/AllSequence.cpp
+++ b/src/main/file/all/AllSequence.cpp
@@ -1,11 +1,13 @@
-#include <file/all/AllSequence.hpp>
+#include "AllSequence.hpp"
+
+#include "AllEvent.hpp"
+#include "AllParser.hpp"
+#include "BarList.hpp"
+#include "SequenceNames.hpp"
+#include "Tracks.hpp"
 
 #include <Util.hpp>
-#include <file/all/AllEvent.hpp>
-#include <file/all/AllParser.hpp>
-#include <file/all/BarList.hpp>
-#include <file/all/SequenceNames.hpp>
-#include <file/all/Tracks.hpp>
+
 #include <sequencer/Event.hpp>
 #include <sequencer/MixerEvent.hpp>
 #include <sequencer/Sequence.hpp>
@@ -19,368 +21,360 @@
 
 #include <cmath>
 
-using namespace std;
-using namespace moduru::lang;
 using namespace mpc::file::all;
+using namespace mpc::sequencer;
+using namespace moduru::file;
+using namespace moduru::lang;
+using namespace moduru;
+using namespace std;
 
-Sequence::Sequence(const vector<char>& b) 
+AllSequence::AllSequence(const vector<char>& bytes)
 {
-	barList = new BarList(moduru::VecUtil::CopyOfRange(b, BAR_LIST_OFFSET, BAR_LIST_OFFSET + BAR_LIST_LENGTH));
-	auto nameBytes = moduru::VecUtil::CopyOfRange(b, NAME_OFFSET, NAME_OFFSET + AllParser::NAME_LENGTH);
-	name = "";
-	
-	for (char c : nameBytes)
-	{
-		if (c == 0x00)
-		{
-			break;
-		}
-		name.push_back(c);
-	}
-
-	tempo = getTempoDouble(vector<char>{ b[TEMPO_BYTE1_OFFSET] , b[TEMPO_BYTE2_OFFSET] });
-	auto barCountBytes = vector<char>{ b[BAR_COUNT_BYTE1_OFFSET], b[BAR_COUNT_BYTE2_OFFSET] };
-	barCount = moduru::file::ByteUtil::bytes2ushort(barCountBytes);
-	loopFirst = moduru::file::ByteUtil::bytes2ushort(vector<char>{ b[LOOP_FIRST_OFFSET], b[LOOP_FIRST_OFFSET + 1] });
-	loopLast = moduru::file::ByteUtil::bytes2ushort(vector<char>{ b[LOOP_LAST_OFFSET], b[LOOP_LAST_OFFSET + 1] });
-
-	if (loopLast > 998)
-	{
-		loopLast = barCount;
-		loopLastEnd = true;
-	}
-	
-	loop = (b[LOOP_ENABLED_OFFSET] > 0);
-	
-	for (int i = 0; i < 33; i++)
-	{
-		auto offset = DEVICE_NAMES_OFFSET + (i * AllParser::DEV_NAME_LENGTH);
-		string stringBuffer = "";
-		auto stringBytes = moduru::VecUtil::CopyOfRange(b, offset, offset + AllParser::DEV_NAME_LENGTH);
-
-		for (char c : stringBytes)
-		{
-			if (c == 0x00)
-			{
-				break;
-			}
-			stringBuffer.push_back(c);
-		}
-		devNames[i] = stringBuffer;
-	}
-	tracks = new Tracks(moduru::VecUtil::CopyOfRange(b, TRACKS_OFFSET, TRACKS_LENGTH));
-	allEvents = readEvents(b);
-}
-
-Sequence::Sequence(mpc::sequencer::Sequence* seq, int number)
-{
-	auto segmentCountLastEventIndex = SequenceNames::getSegmentCount(seq);
-	auto segmentCount = getSegmentCount(seq);
-	auto terminatorCount = (segmentCount & 1) == 0 ? 2 : 1;
-	saveBytes = vector<char>(10240 + (segmentCount * Sequence::EVENT_SEG_LENGTH) + (terminatorCount * Sequence::EVENT_SEG_LENGTH));
-
-	for (int i = 0; i < AllParser::NAME_LENGTH; i++)
-	{
-		saveBytes[i] = StrUtil::padRight(seq->getName(), " ", AllParser::NAME_LENGTH)[i];
-	}
-
-	if ((segmentCountLastEventIndex & 1) != 0)
-	{
-		segmentCountLastEventIndex--;
-	}
-
-	segmentCountLastEventIndex /= 2;
-	auto lastEventIndexBytes = moduru::file::ByteUtil::ushort2bytes(1 + (segmentCountLastEventIndex < 0 ? 0 : segmentCountLastEventIndex));
-	saveBytes[LAST_EVENT_INDEX_OFFSET] = lastEventIndexBytes[0];
-	saveBytes[LAST_EVENT_INDEX_OFFSET + 1] = lastEventIndexBytes[1];
-	
-	for (int i = Sequence::PADDING1_OFFSET; i < PADDING1_OFFSET + PADDING1.size(); i++)
-	{
-		saveBytes[i] = PADDING1[i - PADDING1_OFFSET];
-	}
-
-	setTempoDouble(seq->getInitialTempo());
-	
-	for (int i = Sequence::PADDING2_OFFSET; i < PADDING2_OFFSET + PADDING2.size(); i++)
-	{
-		saveBytes[i] = PADDING2[i - PADDING2_OFFSET];
-	}
-
-	setBarCount(seq->getLastBarIndex() + 1);
-	setLastTick(seq);
-	saveBytes[SEQUENCE_INDEX_OFFSET] = (number);
-	setUnknown32BitInt(seq);
-	auto loopStartBytes = moduru::file::ByteUtil::ushort2bytes(seq->getFirstLoopBarIndex());
-	auto loopEndBytes = moduru::file::ByteUtil::ushort2bytes(seq->getLastLoopBarIndex());
-	
-	if (seq->isLastLoopBarEnd())
-	{
-		loopEndBytes = vector<char>{ (char)255, (char)255 };
-	}
-
-	saveBytes[LOOP_FIRST_OFFSET] = loopStartBytes[0];
-	saveBytes[LOOP_FIRST_OFFSET + 1] = loopStartBytes[1];
-	saveBytes[LOOP_LAST_OFFSET] = loopEndBytes[0];
-	saveBytes[LOOP_LAST_OFFSET + 1] = loopEndBytes[1];
-	saveBytes[LOOP_ENABLED_OFFSET] = seq->isLoopEnabled() ? 1 : 0;
-	
-	for (int i = 0; i < PADDING4.size(); i++)
-	{
-		saveBytes[PADDING4_OFFSET + i] = PADDING4[i];
-	}
-
-	for (int i = 0; i < 33; i++)
-	{
-		auto offset = DEVICE_NAMES_OFFSET + (i * AllParser::DEV_NAME_LENGTH);
-
-		for (int j = 0; j < AllParser::DEV_NAME_LENGTH; j++)
-		{
-			saveBytes[offset + j] = StrUtil::padRight(seq->getDeviceName(i), " ", AllParser::DEV_NAME_LENGTH)[j];
-		}
-	}
-	auto tracks = Tracks(seq);
-
-	for (int i = 0; i < TRACKS_LENGTH; i++)
-	{
-		saveBytes[i + TRACKS_OFFSET] = tracks.getBytes()[i];
-	}
-
-	auto barList = BarList(seq);
-
-	for (int i = Sequence::BAR_LIST_OFFSET; i < BAR_LIST_OFFSET + BAR_LIST_LENGTH; i++)
-	{
-		saveBytes[i] = barList.getBytes()[i - BAR_LIST_OFFSET];
-	}
-
-	auto eventArraysChunk = createEventSegmentsChunk(seq);
-
-	for (int i = Sequence::EVENTS_OFFSET; i < EVENTS_OFFSET + eventArraysChunk.size(); i++)
-	{
-		saveBytes[i] = eventArraysChunk[i - EVENTS_OFFSET];
-	}
-
-	for (int i = (int)(saveBytes.size()) - 8; i < saveBytes.size(); i++)
-	{
-		saveBytes[i] = (255);
-	}
-}
-
-const int Sequence::MAX_SYSEX_SIZE;
-const int Sequence::EVENT_ID_OFFSET;
-const char Sequence::POLY_PRESSURE_ID;
-const char Sequence::CONTROL_CHANGE_ID;
-const char Sequence::PGM_CHANGE_ID;
-const char Sequence::CH_PRESSURE_ID;
-const char Sequence::PITCH_BEND_ID;
-const char Sequence::SYS_EX_ID;
-const char Sequence::SYS_EX_TERMINATOR_ID;
-vector<char> Sequence::TERMINATOR = vector<char>{ (char) 0xFF, (char)0xFF, (char)0xFF, (char)0xFF, (char)0xFF, (char)0xFF, (char)0xFF, (char)0xFF };
-const int Sequence::MAX_EVENT_SEG_COUNT;
-const int Sequence::EVENT_SEG_LENGTH;
-const int Sequence::NAME_OFFSET;
-const int Sequence::LAST_EVENT_INDEX_OFFSET;
-const int Sequence::SEQUENCE_INDEX_OFFSET;
-const int Sequence::PADDING1_OFFSET;
-vector<char> Sequence::PADDING1 = vector<char>{ 1, 1, 0 };
-const int Sequence::TEMPO_BYTE1_OFFSET;
-const int Sequence::TEMPO_BYTE2_OFFSET;
-const int Sequence::PADDING2_OFFSET;
-vector<char> Sequence::PADDING2 = vector<char>{ 4, 4 };
-const int Sequence::BAR_COUNT_BYTE1_OFFSET;
-const int Sequence::BAR_COUNT_BYTE2_OFFSET;
-const int Sequence::LAST_TICK_BYTE1_OFFSET;
-const int Sequence::LAST_TICK_BYTE2_OFFSET;
-const int Sequence::UNKNOWN32_BIT_INT_OFFSET;
-const int Sequence::LOOP_FIRST_OFFSET;
-const int Sequence::LOOP_LAST_OFFSET;
-const int Sequence::LOOP_ENABLED_OFFSET;
-const int Sequence::PADDING4_OFFSET;
-vector<char> Sequence::PADDING4 = vector<char>{ 40, 0, (char) 128, 0, 0 };
-const int Sequence::LAST_TICK_BYTE3_OFFSET;
-const int Sequence::LAST_TICK_BYTE4_OFFSET;
-const int Sequence::DEVICE_NAMES_OFFSET;
-const int Sequence::TRACKS_OFFSET;
-const int Sequence::TRACKS_LENGTH;
-const int Sequence::BAR_LIST_OFFSET;
-const int Sequence::BAR_LIST_LENGTH;
-const int Sequence::EVENTS_OFFSET;
-
-vector<mpc::sequencer::Event*> Sequence::readEvents(const vector<char>& seqBytes)
-{
-	vector<mpc::sequencer::Event*> aeList;
-	
-    for (auto& ba : readEventSegments(seqBytes))
-    {
-		auto ae = AllEvent(ba);
-		aeList.push_back(ae.getEvent());
-	}
+    barList = new BarList(VecUtil::CopyOfRange(bytes, BAR_LIST_OFFSET, BAR_LIST_OFFSET + BAR_LIST_LENGTH));
+    auto nameBytes = VecUtil::CopyOfRange(bytes, NAME_OFFSET, NAME_OFFSET + AllParser::NAME_LENGTH);
+    name = "";
     
-	return aeList;
-}
-
-vector<vector<char>> Sequence::readEventSegments(const vector<char>& seqBytes)
-{
-	vector<vector<char>> eventArrays;
-	int candidateOffset = Sequence::EVENTS_OFFSET;
-    
-	for (int i = 0; i < MAX_EVENT_SEG_COUNT; i++)
+    for (char c : nameBytes)
     {
-		int sysexSegs = 0;
-		auto ea = moduru::VecUtil::CopyOfRange(seqBytes, candidateOffset, candidateOffset + EVENT_SEG_LENGTH);
-	
-        if (moduru::VecUtil::Equals(ea, TERMINATOR))
+        if (c == 0x00)
             break;
+        
+        name.push_back(c);
+    }
+    
+    tempo = getTempoDouble(vector<char>{ bytes[TEMPO_BYTE1_OFFSET] , bytes[TEMPO_BYTE2_OFFSET] });
+    auto barCountBytes = vector<char>{ bytes[BAR_COUNT_BYTE1_OFFSET], bytes[BAR_COUNT_BYTE2_OFFSET] };
+    barCount = ByteUtil::bytes2ushort(barCountBytes);
+    loopFirst = ByteUtil::bytes2ushort(vector<char>{ bytes[LOOP_FIRST_OFFSET], bytes[LOOP_FIRST_OFFSET + 1] });
+    loopLast = ByteUtil::bytes2ushort(vector<char>{ bytes[LOOP_LAST_OFFSET], bytes[LOOP_LAST_OFFSET + 1] });
+    
+    if (loopLast > 998)
+    {
+        loopLast = barCount;
+        loopLastEnd = true;
+    }
+    
+    loop = (bytes[LOOP_ENABLED_OFFSET] > 0);
+    
+    for (int i = 0; i < 33; i++)
+    {
+        auto offset = DEVICE_NAMES_OFFSET + (i * AllParser::DEV_NAME_LENGTH);
+        string stringBuffer = "";
+        auto stringBytes = VecUtil::CopyOfRange(bytes, offset, offset + AllParser::DEV_NAME_LENGTH);
+        
+        for (char c : stringBytes)
+        {
+            if (c == 0x00)
+                break;
 
-		if (ea[EVENT_ID_OFFSET] == SYS_EX_ID) {
-			for (sysexSegs = 0; sysexSegs < MAX_SYSEX_SIZE; sysexSegs++)
+            stringBuffer.push_back(c);
+        }
+        
+        devNames[i] = stringBuffer;
+    }
+    
+    tracks = new Tracks(VecUtil::CopyOfRange(bytes, TRACKS_OFFSET, TRACKS_LENGTH));
+    allEvents = readEvents(bytes);
+}
+
+AllSequence::AllSequence(mpc::sequencer::Sequence* seq, int number)
+{
+    auto segmentCountLastEventIndex = SequenceNames::getSegmentCount(seq);
+    auto segmentCount = getSegmentCount(seq);
+    auto terminatorCount = (segmentCount & 1) == 0 ? 2 : 1;
+    saveBytes = vector<char>(10240 + (segmentCount * AllSequence::EVENT_SEG_LENGTH) + (terminatorCount * AllSequence::EVENT_SEG_LENGTH));
+    
+    for (int i = 0; i < AllParser::NAME_LENGTH; i++)
+    {
+        saveBytes[i] = StrUtil::padRight(seq->getName(), " ", AllParser::NAME_LENGTH)[i];
+    }
+    
+    if ((segmentCountLastEventIndex & 1) != 0)
+    {
+        segmentCountLastEventIndex--;
+    }
+    
+    segmentCountLastEventIndex /= 2;
+    auto lastEventIndexBytes = ByteUtil::ushort2bytes(1 + (segmentCountLastEventIndex < 0 ? 0 : segmentCountLastEventIndex));
+    saveBytes[LAST_EVENT_INDEX_OFFSET] = lastEventIndexBytes[0];
+    saveBytes[LAST_EVENT_INDEX_OFFSET + 1] = lastEventIndexBytes[1];
+    
+    for (int i = AllSequence::PADDING1_OFFSET; i < PADDING1_OFFSET + PADDING1.size(); i++)
+    {
+        saveBytes[i] = PADDING1[i - PADDING1_OFFSET];
+    }
+    
+    setTempoDouble(seq->getInitialTempo());
+    
+    for (int i = AllSequence::PADDING2_OFFSET; i < PADDING2_OFFSET + PADDING2.size(); i++)
+    {
+        saveBytes[i] = PADDING2[i - PADDING2_OFFSET];
+    }
+    
+    setBarCount(seq->getLastBarIndex() + 1);
+    setLastTick(seq);
+    saveBytes[SEQUENCE_INDEX_OFFSET] = (number);
+    setUnknown32BitInt(seq);
+    auto loopStartBytes = ByteUtil::ushort2bytes(seq->getFirstLoopBarIndex());
+    auto loopEndBytes = ByteUtil::ushort2bytes(seq->getLastLoopBarIndex());
+    
+    if (seq->isLastLoopBarEnd())
+    {
+        loopEndBytes = vector<char>{ (char)255, (char)255 };
+    }
+    
+    saveBytes[LOOP_FIRST_OFFSET] = loopStartBytes[0];
+    saveBytes[LOOP_FIRST_OFFSET + 1] = loopStartBytes[1];
+    saveBytes[LOOP_LAST_OFFSET] = loopEndBytes[0];
+    saveBytes[LOOP_LAST_OFFSET + 1] = loopEndBytes[1];
+    saveBytes[LOOP_ENABLED_OFFSET] = seq->isLoopEnabled() ? 1 : 0;
+    
+    for (int i = 0; i < PADDING4.size(); i++)
+    {
+        saveBytes[PADDING4_OFFSET + i] = PADDING4[i];
+    }
+    
+    for (int i = 0; i < 33; i++)
+    {
+        auto offset = DEVICE_NAMES_OFFSET + (i * AllParser::DEV_NAME_LENGTH);
+        
+        for (int j = 0; j < AllParser::DEV_NAME_LENGTH; j++)
+        {
+            saveBytes[offset + j] = StrUtil::padRight(seq->getDeviceName(i), " ", AllParser::DEV_NAME_LENGTH)[j];
+        }
+    }
+    auto tracks = Tracks(seq);
+    
+    for (int i = 0; i < TRACKS_LENGTH; i++)
+    {
+        saveBytes[i + TRACKS_OFFSET] = tracks.getBytes()[i];
+    }
+    
+    auto barList = BarList(seq);
+    
+    for (int i = AllSequence::BAR_LIST_OFFSET; i < BAR_LIST_OFFSET + BAR_LIST_LENGTH; i++)
+    {
+        saveBytes[i] = barList.getBytes()[i - BAR_LIST_OFFSET];
+    }
+    
+    auto eventArraysChunk = createEventSegmentsChunk(seq);
+    
+    for (int i = AllSequence::EVENTS_OFFSET; i < EVENTS_OFFSET + eventArraysChunk.size(); i++)
+    {
+        saveBytes[i] = eventArraysChunk[i - EVENTS_OFFSET];
+    }
+    
+    for (int i = (int)(saveBytes.size()) - 8; i < saveBytes.size(); i++)
+    {
+        saveBytes[i] = (255);
+    }
+}
+
+const int AllSequence::MAX_SYSEX_SIZE;
+const int AllSequence::EVENT_ID_OFFSET;
+const char AllSequence::POLY_PRESSURE_ID;
+const char AllSequence::CONTROL_CHANGE_ID;
+const char AllSequence::PGM_CHANGE_ID;
+const char AllSequence::CH_PRESSURE_ID;
+const char AllSequence::PITCH_BEND_ID;
+const char AllSequence::SYS_EX_ID;
+const char AllSequence::SYS_EX_TERMINATOR_ID;
+vector<char> AllSequence::TERMINATOR = vector<char>{ (char) 0xFF, (char)0xFF, (char)0xFF, (char)0xFF, (char)0xFF, (char)0xFF, (char)0xFF, (char)0xFF };
+const int AllSequence::MAX_EVENT_SEG_COUNT;
+const int AllSequence::EVENT_SEG_LENGTH;
+const int AllSequence::NAME_OFFSET;
+const int AllSequence::LAST_EVENT_INDEX_OFFSET;
+const int AllSequence::SEQUENCE_INDEX_OFFSET;
+const int AllSequence::PADDING1_OFFSET;
+vector<char> AllSequence::PADDING1 = vector<char>{ 1, 1, 0 };
+const int AllSequence::TEMPO_BYTE1_OFFSET;
+const int AllSequence::TEMPO_BYTE2_OFFSET;
+const int AllSequence::PADDING2_OFFSET;
+vector<char> AllSequence::PADDING2 = vector<char>{ 4, 4 };
+const int AllSequence::BAR_COUNT_BYTE1_OFFSET;
+const int AllSequence::BAR_COUNT_BYTE2_OFFSET;
+const int AllSequence::LAST_TICK_BYTE1_OFFSET;
+const int AllSequence::LAST_TICK_BYTE2_OFFSET;
+const int AllSequence::UNKNOWN32_BIT_INT_OFFSET;
+const int AllSequence::LOOP_FIRST_OFFSET;
+const int AllSequence::LOOP_LAST_OFFSET;
+const int AllSequence::LOOP_ENABLED_OFFSET;
+const int AllSequence::PADDING4_OFFSET;
+vector<char> AllSequence::PADDING4 = vector<char>{ 40, 0, (char) 128, 0, 0 };
+const int AllSequence::LAST_TICK_BYTE3_OFFSET;
+const int AllSequence::LAST_TICK_BYTE4_OFFSET;
+const int AllSequence::DEVICE_NAMES_OFFSET;
+const int AllSequence::TRACKS_OFFSET;
+const int AllSequence::TRACKS_LENGTH;
+const int AllSequence::BAR_LIST_OFFSET;
+const int AllSequence::BAR_LIST_LENGTH;
+const int AllSequence::EVENTS_OFFSET;
+
+vector<shared_ptr<mpc::sequencer::Event>> AllSequence::readEvents(const vector<char>& sequenceBytes)
+{
+    vector<shared_ptr<Event>> events;
+    
+    for (auto& eventBytes : readEventSegments(sequenceBytes))
+        events.push_back(AllEvent::bytesToMpcEvent(eventBytes));
+    
+    return events;
+}
+
+vector<vector<char>> AllSequence::readEventSegments(const vector<char>& seqBytes)
+{
+    vector<vector<char>> eventArrays;
+    int candidateOffset = AllSequence::EVENTS_OFFSET;
+    
+    for (int i = 0; i < MAX_EVENT_SEG_COUNT; i++)
+    {
+        int sysexSegs = 0;
+        auto ea = VecUtil::CopyOfRange(seqBytes, candidateOffset, candidateOffset + EVENT_SEG_LENGTH);
+        
+        if (VecUtil::Equals(ea, TERMINATOR))
+            break;
+        
+        if (ea[EVENT_ID_OFFSET] == SYS_EX_ID) {
+            for (sysexSegs = 0; sysexSegs < MAX_SYSEX_SIZE; sysexSegs++)
             {
-				auto potentialTerminator = moduru::VecUtil::CopyOfRange(seqBytes, candidateOffset + (sysexSegs * EVENT_SEG_LENGTH), candidateOffset + (sysexSegs * EVENT_SEG_LENGTH) + EVENT_SEG_LENGTH);
-			
+                auto potentialTerminator = VecUtil::CopyOfRange(seqBytes, candidateOffset + (sysexSegs * EVENT_SEG_LENGTH), candidateOffset + (sysexSegs * EVENT_SEG_LENGTH) + EVENT_SEG_LENGTH);
+                
                 if (potentialTerminator[EVENT_ID_OFFSET] == SYS_EX_TERMINATOR_ID)
                     break;
-			}
-			
+            }
+            
             sysexSegs++;
-			ea = moduru::VecUtil::CopyOfRange(seqBytes, candidateOffset, candidateOffset + (sysexSegs * EVENT_SEG_LENGTH));
-		}
-		eventArrays.push_back(ea);
-		candidateOffset += (int)(ea.size());
-	}
-	return eventArrays;
+            ea = VecUtil::CopyOfRange(seqBytes, candidateOffset, candidateOffset + (sysexSegs * EVENT_SEG_LENGTH));
+        }
+        eventArrays.push_back(ea);
+        candidateOffset += (int)(ea.size());
+    }
+    return eventArrays;
 }
 
-double Sequence::getTempoDouble(const vector<char>& bytePair)
+double AllSequence::getTempoDouble(const vector<char>& bytePair)
 {
-	double k = 0;
-	auto s = moduru::file::ByteUtil::bytes2ushort(bytePair);
-	k = static_cast<double>(s);
-	return k / 10.0;
+    double k = 0;
+    auto s = ByteUtil::bytes2ushort(bytePair);
+    k = static_cast<double>(s);
+    return k / 10.0;
 }
 
-int Sequence::getNumberOfEventSegmentsForThisSeq(const vector<char>& seqBytes)
+int AllSequence::getNumberOfEventSegmentsForThisSeq(const vector<char>& seqBytes)
 {
-	auto accum = 0;
+    auto accum = 0;
     
-	for (auto& ba : readEventSegments(seqBytes))
-		accum += (int) (ba.size()) / 8;
-
-	return accum;
+    for (auto& ba : readEventSegments(seqBytes))
+        accum += (int) (ba.size()) / 8;
+    
+    return accum;
 }
 
-int Sequence::getEventAmount()
+int AllSequence::getEventAmount()
 {
-	return (int)(allEvents.size());
+    return (int)(allEvents.size());
 }
 
-int Sequence::getSegmentCount(mpc::sequencer::Sequence* seq)
+int AllSequence::getSegmentCount(mpc::sequencer::Sequence* seq)
 {
-	int segmentCount = 0;
-	
-	for (auto& track : seq->getTracks())
-	{
-		auto t = track.lock();
-		
-		if (t->getIndex() > 63)
-		{
-			break;
-		}
-
-		for (auto& e : t->getEvents())
-		{
-			auto sysExEvent = dynamic_pointer_cast<mpc::sequencer::SystemExclusiveEvent>(e.lock());
-			auto mixerEvent = dynamic_pointer_cast<mpc::sequencer::MixerEvent>(e.lock());
-			
-			if (sysExEvent)
-			{
-				int dataSegments = (int)(ceil((int)(sysExEvent->getBytes().size()) / 8.0));
-				segmentCount += dataSegments + 2;
-			}
-			else if (mixerEvent)
-			{
-				segmentCount += 4;
-			}
-			else
-			{
-				segmentCount++;
-			}
-		}
-	}
-	return segmentCount;
+    int segmentCount = 0;
+    
+    for (auto& track : seq->getTracks())
+    {
+        auto t = track.lock();
+        
+        if (t->getIndex() > 63)
+            break;
+        
+        for (auto& e : t->getEvents())
+        {
+            auto sysExEvent = dynamic_pointer_cast<mpc::sequencer::SystemExclusiveEvent>(e.lock());
+            auto mixerEvent = dynamic_pointer_cast<mpc::sequencer::MixerEvent>(e.lock());
+            
+            if (sysExEvent)
+            {
+                int dataSegments = (int)(ceil((int)(sysExEvent->getBytes().size()) / 8.0));
+                segmentCount += dataSegments + 2;
+            }
+            else if (mixerEvent)
+            {
+                segmentCount += 4;
+            }
+            else
+            {
+                segmentCount++;
+            }
+        }
+    }
+    return segmentCount;
 }
 
-void Sequence::setUnknown32BitInt(mpc::sequencer::Sequence* seq)
+void AllSequence::setUnknown32BitInt(mpc::sequencer::Sequence* seq)
 {
-	auto unknownNumberBytes1 = moduru::file::ByteUtil::uint2bytes(10000000);
-	auto unknownNumberBytes2 = moduru::file::ByteUtil::uint2bytes(seq->getLastTick() * 5208.333333333333);
-	
-	for (int i = 0; i < 2; i++)
-	{
-		for (int j = 0; j < 4; j++)
-		{
-			saveBytes[UNKNOWN32_BIT_INT_OFFSET + j + (i * 4)] = unknownNumberBytes1[j];
-		}
-	}
-
-	for (int i = 2; i < 4; i++)
-	{
-		for (int j = 0; j < 4; j++)
-		{
-			saveBytes[UNKNOWN32_BIT_INT_OFFSET + j + (i * 4)] = unknownNumberBytes2[j];
-		}
-	}
+    auto unknownNumberBytes1 = ByteUtil::uint2bytes(10000000);
+    auto unknownNumberBytes2 = ByteUtil::uint2bytes(seq->getLastTick() * 5208.333333333333);
+    
+    for (int i = 0; i < 2; i++)
+    {
+        for (int j = 0; j < 4; j++)
+            saveBytes[UNKNOWN32_BIT_INT_OFFSET + j + (i * 4)] = unknownNumberBytes1[j];
+    }
+    
+    for (int i = 2; i < 4; i++)
+    {
+        for (int j = 0; j < 4; j++)
+            saveBytes[UNKNOWN32_BIT_INT_OFFSET + j + (i * 4)] = unknownNumberBytes2[j];
+    }
 }
 
-void Sequence::setBarCount(int i)
+void AllSequence::setBarCount(int i)
 {
-    auto ba = moduru::file::ByteUtil::ushort2bytes(i);
+    auto ba = ByteUtil::ushort2bytes(i);
     saveBytes[BAR_COUNT_BYTE1_OFFSET] = ba[0];
     saveBytes[BAR_COUNT_BYTE2_OFFSET] = ba[1];
 }
 
-vector<char> Sequence::createEventSegmentsChunk(mpc::sequencer::Sequence* seq)
+vector<char> AllSequence::createEventSegmentsChunk(mpc::sequencer::Sequence* seq)
 {
-	vector<vector<char>> ea;
-
-	for (int i = 0; i < seq->getLastTick(); i++)
-	{
-		for (auto& track : seq->getTracks())
-		{
-			auto t = track.lock();
-
-			if (t->getIndex() > 63)
-			{
-				break;
-			}
-
-			for (auto& event : t->getEvents())
-			{
-				auto e = event.lock();
-
-				if (e->getTick() == i)
-				{
-					e->setTrack(t->getIndex());
-					auto ae = AllEvent(e.get());
-					ea.push_back(ae.getBytes());
-				}
-			}
-		}
-	}
-	ea.push_back(TERMINATOR);
-	return moduru::file::ByteUtil::stitchByteArrays(ea);
+    vector<vector<char>> ea;
+    
+    for (int i = 0; i < seq->getLastTick(); i++)
+    {
+        for (auto& track : seq->getTracks())
+        {
+            auto t = track.lock();
+            
+            if (t->getIndex() > 63)
+                break;
+            
+            for (auto& event : t->getEvents())
+            {
+                auto e = event.lock();
+                
+                if (e->getTick() == i)
+                {
+                    e->setTrack(t->getIndex());
+                    ea.push_back(AllEvent::mpcEventToBytes(e));
+                }
+            }
+        }
+    }
+    
+    ea.push_back(TERMINATOR);
+    return ByteUtil::stitchByteArrays(ea);
 }
 
-void Sequence::setTempoDouble(double tempo)
+void AllSequence::setTempoDouble(double tempo)
 {
-	auto ba = moduru::file::ByteUtil::ushort2bytes((unsigned short)(tempo * 10.0));
-	saveBytes[TEMPO_BYTE1_OFFSET] = ba[0];
-	saveBytes[TEMPO_BYTE2_OFFSET] = ba[1];
+    auto ba = ByteUtil::ushort2bytes((unsigned short)(tempo * 10.0));
+    saveBytes[TEMPO_BYTE1_OFFSET] = ba[0];
+    saveBytes[TEMPO_BYTE2_OFFSET] = ba[1];
 }
 
-void Sequence::setLastTick(mpc::sequencer::Sequence* seq)
+void AllSequence::setLastTick(mpc::sequencer::Sequence* seq)
 {
     auto lastTick = static_cast< int >(seq->getLastTick());
     auto remainder = lastTick % 65536;
-    auto b = moduru::file::ByteUtil::ushort2bytes(remainder);
+    auto b = ByteUtil::ushort2bytes(remainder);
     auto large = static_cast< int >(floor(lastTick / 65536.0));
     saveBytes[LAST_TICK_BYTE1_OFFSET] = b[0];
     saveBytes[LAST_TICK_BYTE2_OFFSET] = b[1];
@@ -390,7 +384,7 @@ void Sequence::setLastTick(mpc::sequencer::Sequence* seq)
     saveBytes[LAST_TICK_BYTE4_OFFSET + 1] = (large);
 }
 
-vector<char> Sequence::getBytes()
+vector<char> AllSequence::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/AllSequence.cpp
+++ b/src/main/file/all/AllSequence.cpp
@@ -430,7 +430,7 @@ void AllSequence::setLastTick(mpc::sequencer::Sequence* seq)
     saveBytes[LAST_TICK_BYTE4_OFFSET + 1] = (large);
 }
 
-vector<char> AllSequence::getBytes()
+vector<char>& AllSequence::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/AllSequence.hpp
+++ b/src/main/file/all/AllSequence.hpp
@@ -17,7 +17,7 @@ class Tracks;
 
 namespace mpc::file::all
 {
-class Sequence
+class AllSequence
 {
     
 public:
@@ -86,13 +86,13 @@ public:
     std::vector<std::string> devNames = std::vector<std::string>(33);
     Tracks* tracks;
     BarList* barList;
-    std::vector<mpc::sequencer::Event*> allEvents;
+    std::vector<std::shared_ptr<mpc::sequencer::Event>> allEvents;
     
 private:
     std::vector<char> saveBytes;
     
 private:
-    static std::vector<mpc::sequencer::Event*> readEvents(const std::vector<char>& seqBytes);
+    static std::vector<std::shared_ptr<mpc::sequencer::Event>> readEvents(const std::vector<char>& seqBytes);
     static std::vector<std::vector<char>> readEventSegments(const std::vector<char>& seqBytes);
     double getTempoDouble(const std::vector<char>& bytePair);
     
@@ -111,8 +111,8 @@ private:
 public:
     std::vector<char> getBytes();
     
-    Sequence(const std::vector<char>& b);
-    Sequence(mpc::sequencer::Sequence* seq, int number);
+    AllSequence(const std::vector<char>& b);
+    AllSequence(mpc::sequencer::Sequence* seq, int number);
     
 };
 }

--- a/src/main/file/all/AllSequence.hpp
+++ b/src/main/file/all/AllSequence.hpp
@@ -109,7 +109,7 @@ private:
     void setLastTick(mpc::sequencer::Sequence* seq);
     
 public:
-    std::vector<char> getBytes();
+    std::vector<char>& getBytes();
     
     void applyToMpcSeq(std::shared_ptr<mpc::sequencer::Sequence> mpcSeq);
     

--- a/src/main/file/all/AllSequence.hpp
+++ b/src/main/file/all/AllSequence.hpp
@@ -111,6 +111,8 @@ private:
 public:
     std::vector<char> getBytes();
     
+    void applyToMpcSeq(std::shared_ptr<mpc::sequencer::Sequence> mpcSeq);
+    
     AllSequence(const std::vector<char>& b);
     AllSequence(mpc::sequencer::Sequence* seq, int number);
     

--- a/src/main/file/all/AllSequencer.cpp
+++ b/src/main/file/all/AllSequencer.cpp
@@ -44,15 +44,9 @@ AllSequencer::AllSequencer(mpc::Mpc& mpc)
 	saveBytes[SECOND_SEQ_INDEX_OFFSET] = secondSequenceScreen->sq;
 }
 
-const int AllSequencer::LENGTH;
 vector<char> AllSequencer::TEMPLATE = vector<char>{ 0, 0, 0, 0 , (char) 176, 4, 1, 3, 0, 0, 0, 0, 12, 0, 0, 0 };
-const int AllSequencer::SEQ_OFFSET;
-const int AllSequencer::TR_OFFSET;
-const int AllSequencer::TC_OFFSET;
-const int AllSequencer::SECOND_SEQ_ENABLED_OFFSET;
-const int AllSequencer::SECOND_SEQ_INDEX_OFFSET;
 
-vector<char> AllSequencer::getBytes()
+vector<char>& AllSequencer::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/AllSequencer.cpp
+++ b/src/main/file/all/AllSequencer.cpp
@@ -1,6 +1,7 @@
-#include <file/all/AllSequencer.hpp>
+#include "AllSequencer.hpp"
 
 #include <Mpc.hpp>
+
 #include <sequencer/Sequencer.hpp>
 
 #include <lcdgui/Screens.hpp>
@@ -13,7 +14,7 @@ using namespace mpc::lcdgui::screens;
 using namespace mpc::lcdgui::screens::window;
 using namespace std;
 
-mpc::file::all::Sequencer::Sequencer(mpc::Mpc& mpc, const vector<char>& loadBytes)
+AllSequencer::AllSequencer(mpc::Mpc& mpc, const vector<char>& loadBytes)
 	: mpc(mpc)
 {
 	sequence = loadBytes[SEQ_OFFSET];
@@ -23,7 +24,7 @@ mpc::file::all::Sequencer::Sequencer(mpc::Mpc& mpc, const vector<char>& loadByte
 	secondSeqIndex = loadBytes[SECOND_SEQ_INDEX_OFFSET];
 }
 
-mpc::file::all::Sequencer::Sequencer(mpc::Mpc& mpc)
+AllSequencer::AllSequencer(mpc::Mpc& mpc)
 	: mpc(mpc)
 {
 	saveBytes = vector<char>(LENGTH);
@@ -43,15 +44,15 @@ mpc::file::all::Sequencer::Sequencer(mpc::Mpc& mpc)
 	saveBytes[SECOND_SEQ_INDEX_OFFSET] = secondSequenceScreen->sq;
 }
 
-const int mpc::file::all::Sequencer::LENGTH;
-vector<char> mpc::file::all::Sequencer::TEMPLATE = vector<char>{ 0, 0, 0, 0 , (char) 176, 4, 1, 3, 0, 0, 0, 0, 12, 0, 0, 0 };
-const int mpc::file::all::Sequencer::SEQ_OFFSET;
-const int mpc::file::all::Sequencer::TR_OFFSET;
-const int mpc::file::all::Sequencer::TC_OFFSET;
-const int mpc::file::all::Sequencer::SECOND_SEQ_ENABLED_OFFSET;
-const int mpc::file::all::Sequencer::SECOND_SEQ_INDEX_OFFSET;
+const int AllSequencer::LENGTH;
+vector<char> AllSequencer::TEMPLATE = vector<char>{ 0, 0, 0, 0 , (char) 176, 4, 1, 3, 0, 0, 0, 0, 12, 0, 0, 0 };
+const int AllSequencer::SEQ_OFFSET;
+const int AllSequencer::TR_OFFSET;
+const int AllSequencer::TC_OFFSET;
+const int AllSequencer::SECOND_SEQ_ENABLED_OFFSET;
+const int AllSequencer::SECOND_SEQ_INDEX_OFFSET;
 
-vector<char> mpc::file::all::Sequencer::getBytes()
+vector<char> AllSequencer::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/AllSequencer.hpp
+++ b/src/main/file/all/AllSequencer.hpp
@@ -7,33 +7,34 @@ namespace mpc { class Mpc; }
 
 namespace mpc::file::all
 {
-	class Sequencer
-	{
-	public:
-		static const int LENGTH{ 16 };
-
-	private:
-		mpc::Mpc& mpc;
-		static std::vector<char> TEMPLATE;
-
-	public:
-		static const int SEQ_OFFSET{ 0 };
-		static const int TR_OFFSET{ 2 };
-		static const int TC_OFFSET{ 7 };
-		static const int SECOND_SEQ_ENABLED_OFFSET{ 9 };
-		static const int SECOND_SEQ_INDEX_OFFSET{ 10 };
-		int sequence;
-		int track;
-		int tc;
-		bool secondSeqEnabled;
-		int secondSeqIndex;
-		std::vector<char> saveBytes;
-
-	public:
-		std::vector<char> getBytes();
-
-		Sequencer(mpc::Mpc& mpc, const std::vector<char>& loadBytes);
-		Sequencer(mpc::Mpc& mpc);
-
-	};
+class AllSequencer
+{
+public:
+    static const int LENGTH = 16;
+    
+private:
+    mpc::Mpc& mpc;
+    static std::vector<char> TEMPLATE;
+    
+public:
+    static const int SEQ_OFFSET = 0;
+    static const int TR_OFFSET = 2;
+    static const int TC_OFFSET = 7;
+    static const int SECOND_SEQ_ENABLED_OFFSET = 9;
+    static const int SECOND_SEQ_INDEX_OFFSET = 10;
+    
+    int sequence;
+    int track;
+    int tc;
+    bool secondSeqEnabled;
+    int secondSeqIndex;
+    std::vector<char> saveBytes;
+    
+public:
+    std::vector<char> getBytes();
+    
+    AllSequencer(mpc::Mpc& mpc, const std::vector<char>& loadBytes);
+    AllSequencer(mpc::Mpc& mpc);
+    
+};
 }

--- a/src/main/file/all/AllSequencer.hpp
+++ b/src/main/file/all/AllSequencer.hpp
@@ -31,7 +31,7 @@ public:
     std::vector<char> saveBytes;
     
 public:
-    std::vector<char> getBytes();
+    std::vector<char>& getBytes();
     
     AllSequencer(mpc::Mpc& mpc, const std::vector<char>& loadBytes);
     AllSequencer(mpc::Mpc& mpc);

--- a/src/main/file/all/AllSong.cpp
+++ b/src/main/file/all/AllSong.cpp
@@ -43,7 +43,7 @@ string Song::getName()
     return name;
 }
 
-vector<char> Song::getBytes()
+vector<char>& Song::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/AllSong.hpp
+++ b/src/main/file/all/AllSong.hpp
@@ -18,14 +18,14 @@ private:
     static const int NAME_OFFSET{ 0 };
     
 public:
-    std::string name{};
-    std::vector<char> saveBytes{};
+    std::string name;
+    std::vector<char> saveBytes;
     
 public:
     std::string getName();
     
 public:
-    std::vector<char> getBytes();
+    std::vector<char>& getBytes();
     
     Song(const std::vector<char>& b);
     Song(mpc::sequencer::Song* mpcSong);

--- a/src/main/file/all/AllSysExEvent.hpp
+++ b/src/main/file/all/AllSysExEvent.hpp
@@ -11,27 +11,23 @@ class AllSysExEvent
 {
     
 private:
-    static int CHUNK_HEADER_ID_OFFSET;
-    static int BYTE_COUNT_OFFSET;
-    static int DATA_OFFSET;
-    static int MIX_TERMINATOR_ID_OFFSET;
-    static int DATA_HEADER_ID_OFFSET;
-    static char HEADER_ID;
-    static char  DATA_TERMINATOR_ID;
-    static char CHUNK_TERMINATOR_ID;
-    static int MIXER_SIGNATURE_OFFSET;
+    const static int CHUNK_HEADER_ID_OFFSET = 4;
+    const static int BYTE_COUNT_OFFSET = 5;
+    const static int DATA_OFFSET = 8;
+    const static int MIX_TERMINATOR_ID_OFFSET = 28;
+    const static int DATA_HEADER_ID_OFFSET = 8;
+    const static char HEADER_ID = 240;
+    const static char DATA_TERMINATOR_ID = 247;
+    const static char CHUNK_TERMINATOR_ID = 248;
+    const static int MIXER_SIGNATURE_OFFSET = 0;
+    const static int MIXER_PARAMETER_OFFSET = 5;
+    const static int MIXER_PAD_OFFSET = 6;
+    const static int MIXER_VALUE_OFFSET = 7;
+
     static std::vector<char> MIXER_SIGNATURE;
-    static int MIXER_PARAMETER_OFFSET;
-    static int MIXER_PAD_OFFSET;
-    static int MIXER_VALUE_OFFSET;
     
 public:
-    std::vector<char> sysexLoadData{};
-    mpc::sequencer::Event* event {  };
-    std::vector<char> saveBytes{};
-    
-public:
-    AllSysExEvent(const std::vector<char>& ba);
-    AllSysExEvent(mpc::sequencer::Event* e);
+    static std::shared_ptr<mpc::sequencer::Event> bytesToMpcEvent(const std::vector<char>&);
+    static std::vector<char> mpcEventToBytes(std::shared_ptr<mpc::sequencer::Event>);
 };
 }

--- a/src/main/file/all/Bar.cpp
+++ b/src/main/file/all/Bar.cpp
@@ -60,7 +60,7 @@ int Bar::getLastTick()
     return lastTick;
 }
 
-vector<char> Bar::getBytes()
+vector<char>& Bar::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/Bar.hpp
+++ b/src/main/file/all/Bar.hpp
@@ -2,34 +2,28 @@
 
 #include <vector>
 
-namespace mpc {
-	namespace file {
-		namespace all {
+namespace mpc::file::all {
+class Bar;
 
-			class Bar;
-
-			class Bar
-			{
-
-			public:
-				int ticksPerBeat{};
-				int lastTick{};
-				int barLength{};
-				std::vector<char> saveBytes{};
-
-			public:
-				int getTicksPerBeat();
-				int getDenominator();
-				int getNumerator();
-				int getLastTick();
-
-			public:
-				std::vector<char> getBytes();
-
-				Bar(const std::vector<char>& bytes, Bar* previousBar);
-				Bar(int ticksPerBeat, int lastTick);
-			};
-
-		}
-	}
+class Bar
+{
+    
+public:
+    int ticksPerBeat;
+    int lastTick;
+    int barLength;
+    std::vector<char> saveBytes;
+    
+public:
+    int getTicksPerBeat();
+    int getDenominator();
+    int getNumerator();
+    int getLastTick();
+    
+public:
+    std::vector<char>& getBytes();
+    
+    Bar(const std::vector<char>& bytes, Bar* previousBar);
+    Bar(int ticksPerBeat, int lastTick);
+};
 }

--- a/src/main/file/all/BarList.cpp
+++ b/src/main/file/all/BarList.cpp
@@ -62,8 +62,7 @@ vector<Bar*> BarList::getBars()
     return bars;
 }
 
-
-vector<char> BarList::getBytes()
+vector<char>& BarList::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/BarList.hpp
+++ b/src/main/file/all/BarList.hpp
@@ -21,7 +21,7 @@ public:
     std::vector<Bar*> getBars();
     
 public:
-    std::vector<char> getBytes();
+    std::vector<char>& getBytes();
     BarList(const std::vector<char>& loadBytes);
     
 public:

--- a/src/main/file/all/Count.cpp
+++ b/src/main/file/all/Count.cpp
@@ -53,18 +53,6 @@ Count::Count(mpc::Mpc& mpc)
 	saveBytes[NORMAL_VELO_OFFSET] = static_cast< int8_t >(metronomeSoundScreen->getNormalVelo());
 }
 
-const int Count::ENABLED_OFFSET;
-const int Count::COUNT_IN_MODE_OFFSET;
-const int Count::CLICK_VOLUME_OFFSET;
-const int Count::RATE_OFFSET;
-const int Count::ENABLED_IN_PLAY_OFFSET;
-const int Count::ENABLED_IN_REC_OFFSET;
-const int Count::CLICK_OUTPUT_OFFSET;
-const int Count::WAIT_FOR_KEY_ENABLED_OFFSET;
-const int Count::SOUND_OFFSET;
-const int Count::ACCENT_VELO_OFFSET;
-const int Count::NORMAL_VELO_OFFSET;
-
 bool Count::isEnabled()
 {
     return enabled;
@@ -120,7 +108,7 @@ int Count::getNormalVelo()
     return normalVelo;
 }
 
-vector<char> Count::getBytes()
+vector<char>& Count::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/Count.hpp
+++ b/src/main/file/all/Count.hpp
@@ -7,55 +7,55 @@ namespace mpc { class Mpc; }
 
 namespace mpc::file::all {
 
-	class Count
-	{
-
-	public:
-		static const int ENABLED_OFFSET{ 5 };
-		static const int COUNT_IN_MODE_OFFSET{ 6 };
-		static const int CLICK_VOLUME_OFFSET{ 7 };
-		static const int RATE_OFFSET{ 8 };
-		static const int ENABLED_IN_PLAY_OFFSET{ 9 };
-		static const int ENABLED_IN_REC_OFFSET{ 10 };
-		static const int CLICK_OUTPUT_OFFSET{ 11 };
-		static const int WAIT_FOR_KEY_ENABLED_OFFSET{ 12 };
-		static const int SOUND_OFFSET{ 13 };
-		static const int ACCENT_VELO_OFFSET{ 14 };
-		static const int NORMAL_VELO_OFFSET{ 15 };
-		bool enabled{};
-		int countInMode{};
-		int clickVolume{};
-		int rate{};
-		bool enabledInPlay{};
-		bool enabledInRec{};
-		int clickOutput{};
-		bool waitForKeyEnabled{};
-		int sound{};
-		int accentVelo{};
-		int normalVelo{};
-		std::vector<char> saveBytes{};
-
-	public:
-		bool isEnabled();
-		int getCountInMode();
-		int getClickVolume();
-		int getRate();
-		bool isEnabledInPlay();
-		bool isEnabledInRec();
-		int getClickOutput();
-		bool isWaitForKeyEnabled();
-		int getSound();
-		int getAccentVelo();
-		int getNormalVelo();
-
-	public:
-		std::vector<char> getBytes();
-
-		Count(mpc::Mpc& mpc, const std::vector<char>& b);
-		Count(mpc::Mpc& mpc);
-
-	private:
-		mpc::Mpc& mpc;
-
-	};
+class Count
+{
+    
+public:
+    static const int ENABLED_OFFSET{ 5 };
+    static const int COUNT_IN_MODE_OFFSET{ 6 };
+    static const int CLICK_VOLUME_OFFSET{ 7 };
+    static const int RATE_OFFSET{ 8 };
+    static const int ENABLED_IN_PLAY_OFFSET{ 9 };
+    static const int ENABLED_IN_REC_OFFSET{ 10 };
+    static const int CLICK_OUTPUT_OFFSET{ 11 };
+    static const int WAIT_FOR_KEY_ENABLED_OFFSET{ 12 };
+    static const int SOUND_OFFSET{ 13 };
+    static const int ACCENT_VELO_OFFSET{ 14 };
+    static const int NORMAL_VELO_OFFSET{ 15 };
+    bool enabled;
+    int countInMode;
+    int clickVolume;
+    int rate;
+    bool enabledInPlay;
+    bool enabledInRec;
+    int clickOutput;
+    bool waitForKeyEnabled;
+    int sound;
+    int accentVelo;
+    int normalVelo;
+    std::vector<char> saveBytes;
+    
+public:
+    bool isEnabled();
+    int getCountInMode();
+    int getClickVolume();
+    int getRate();
+    bool isEnabledInPlay();
+    bool isEnabledInRec();
+    int getClickOutput();
+    bool isWaitForKeyEnabled();
+    int getSound();
+    int getAccentVelo();
+    int getNormalVelo();
+    
+public:
+    std::vector<char> getBytes();
+    
+    Count(mpc::Mpc& mpc, const std::vector<char>& b);
+    Count(mpc::Mpc& mpc);
+    
+private:
+    mpc::Mpc& mpc;
+    
+};
 }

--- a/src/main/file/all/Count.hpp
+++ b/src/main/file/all/Count.hpp
@@ -49,7 +49,7 @@ public:
     int getNormalVelo();
     
 public:
-    std::vector<char> getBytes();
+    std::vector<char>& getBytes();
     
     Count(mpc::Mpc& mpc, const std::vector<char>& b);
     Count(mpc::Mpc& mpc);

--- a/src/main/file/all/Defaults.cpp
+++ b/src/main/file/all/Defaults.cpp
@@ -18,6 +18,10 @@ using namespace moduru::file;
 using namespace moduru::lang;
 using namespace std;
 
+vector<char> Defaults::UNKNOWN1 = vector<char>{ 1, 0, 0, 1, 1, 0 };
+vector<char> Defaults::UNKNOWN2 = vector<char>{ 0, 0, (char) 0xFF, (char) 0xFF, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    , 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 32, 32, 32, 32, 32, 32, 32 };
+
 Defaults::Defaults(mpc::Mpc& mpc, const vector<char>& loadBytes)
 	: mpc(mpc)
 {
@@ -81,68 +85,53 @@ Defaults::Defaults(mpc::Mpc& mpc)
 	setTrackSettings();
 }
 
-const int Defaults::DEF_SEQ_NAME_OFFSET;
-const int Defaults::UNKNOWN1_OFFSET;
-
-vector<char> Defaults::UNKNOWN1 = vector<char>{ 1, 0, 0, 1, 1, 0 };
-
-const int Defaults::TEMPO_BYTE1_OFFSET;
-const int Defaults::TEMPO_BYTE2_OFFSET;
-const int Defaults::TIMESIG_NUM_OFFSET;
-const int Defaults::TIMESIG_DEN_OFFSET;
-const int Defaults::BAR_COUNT_BYTE1_OFFSET;
-const int Defaults::BAR_COUNT_BYTE2_OFFSET;
-const int Defaults::LAST_TICK_BYTE1_OFFSET;
-const int Defaults::LAST_TICK_BYTE2_OFFSET;
-const int Defaults::LAST_TICK_BYTE3_OFFSET;
-const int Defaults::UNKNOWN32_BIT_INT_OFFSET;
-const int Defaults::UNKNOWN2_OFFSET;
-
-vector<char> Defaults::UNKNOWN2 = vector<char>{ 0, 0, (char) 0xFF, (char) 0xFF, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-	, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 32, 32, 32, 32, 32, 32, 32 };
-
-const int Defaults::DEV_NAMES_OFFSET;
-const int Defaults::DEV_NAMES_LENGTH;
-const int Defaults::TR_NAMES_OFFSET;
-const int Defaults::TR_NAMES_LENGTH;
-const int Defaults::DEVICES_OFFSET;
-const int Defaults::DEVICES_LENGTH;
-const int Defaults::BUSSES_OFFSET;
-const int Defaults::BUSSES_LENGTH;
-const int Defaults::PGMS_OFFSET;
-const int Defaults::PGMS_LENGTH;
-const int Defaults::TR_VELOS_OFFSET;
-const int Defaults::TR_VELOS_LENGTH;
-const int Defaults::TR_STATUS_OFFSET;
-const int Defaults::TR_STATUS_LENGTH;
-
 void Defaults::parseNames(vector<char> loadBytes)
 {
 	vector<char> stringBuffer;
-	stringBuffer = moduru::VecUtil::CopyOfRange(loadBytes, DEF_SEQ_NAME_OFFSET, DEF_SEQ_NAME_OFFSET + AllParser::NAME_LENGTH);
-	defaultSeqName = "";
-	for (char c : stringBuffer) {
-		if (c == 0x00) break;
+	
+    stringBuffer = moduru::VecUtil::CopyOfRange(loadBytes, DEF_SEQ_NAME_OFFSET, DEF_SEQ_NAME_OFFSET + AllParser::NAME_LENGTH);
+	
+    defaultSeqName = "";
+	
+    for (char c : stringBuffer)
+    {
+		if (c == 0x00)
+            break;
+        
 		defaultSeqName.push_back(c);
 	}
-	auto offset = 0;
-	for (int i = 0; i < 33; i++) {
+	
+    auto offset = 0;
+    
+	for (int i = 0; i < 33; i++)
+    {
 		offset = DEV_NAMES_OFFSET + (i * AllParser::DEV_NAME_LENGTH);
 		stringBuffer = moduru::VecUtil::CopyOfRange(loadBytes, offset, offset + AllParser::DEV_NAME_LENGTH);
 		string s = "";
-		for (char c : stringBuffer) {
-			if (c == 0x00) break;
-			s.push_back(c);
+		
+        for (char c : stringBuffer)
+        {
+			if (c == 0x00)
+                break;
+			
+            s.push_back(c);
 		}
+        
 		devNames[i] = s;
 	}
-	for (int i = 0; i < 64; i++) {
+    
+	for (int i = 0; i < 64; i++)
+    {
 		offset = TR_NAMES_OFFSET + (i * AllParser::NAME_LENGTH);
 		stringBuffer = moduru::VecUtil::CopyOfRange(loadBytes, offset, offset + AllParser::NAME_LENGTH);
 		string s = "";
-		for (char c : stringBuffer) {
-			if (c == 0x00) break;
-			s.push_back(c);
+	
+        for (char c : stringBuffer)
+        {
+			if (c == 0x00)
+                break;
+			
+            s.push_back(c);
 		}
 		trackNames[i] = s;
 	}
@@ -288,7 +277,7 @@ void Defaults::setTempo()
 	saveBytes[TEMPO_BYTE2_OFFSET] = tempoBytes[1];
 }
 
-vector<char> Defaults::getBytes()
+vector<char>& Defaults::getBytes()
 {
 	return saveBytes;
 }

--- a/src/main/file/all/Defaults.hpp
+++ b/src/main/file/all/Defaults.hpp
@@ -7,89 +7,90 @@ namespace mpc { class Mpc; }
 
 namespace mpc::file::all {
 
-	class Defaults
-	{
-
-	public:
-		static const int DEF_SEQ_NAME_OFFSET{ 0 };
-		static const int UNKNOWN1_OFFSET{ 16 };
-		static std::vector<char> UNKNOWN1;
-
-	public:
-		static const int TEMPO_BYTE1_OFFSET{ 22 };
-		static const int TEMPO_BYTE2_OFFSET{ 23 };
-		static const int TIMESIG_NUM_OFFSET{ 24 };
-		static const int TIMESIG_DEN_OFFSET{ 25 };
-		static const int BAR_COUNT_BYTE1_OFFSET{ 26 };
-		static const int BAR_COUNT_BYTE2_OFFSET{ 27 };
-		static const int LAST_TICK_BYTE1_OFFSET{ 28 };
-		static const int LAST_TICK_BYTE2_OFFSET{ 29 };
-		static const int LAST_TICK_BYTE3_OFFSET{ 30 };
-		static const int UNKNOWN32_BIT_INT_OFFSET{ 32 };
-		static const int UNKNOWN2_OFFSET{ 48 };
-		static std::vector<char> UNKNOWN2;
-
-	public:
-		static const int DEV_NAMES_OFFSET{ 120 };
-		static const int DEV_NAMES_LENGTH{ 264 };
-		static const int TR_NAMES_OFFSET{ 384 };
-		static const int TR_NAMES_LENGTH{ 1024 };
-		static const int DEVICES_OFFSET{ 1408 };
-		static const int DEVICES_LENGTH{ 64 };
-		static const int BUSSES_OFFSET{ 1472 };
-		static const int BUSSES_LENGTH{ 64 };
-		static const int PGMS_OFFSET{ 1536 };
-		static const int PGMS_LENGTH{ 64 };
-		static const int TR_VELOS_OFFSET{ 1600 };
-		static const int TR_VELOS_LENGTH{ 64 };
-		static const int TR_STATUS_OFFSET{ 1664 };
-		static const int TR_STATUS_LENGTH{ 64 };
-		std::string defaultSeqName = "";
-		int tempo;
-		int timeSigNum;
-		int timeSigDen;
-		int barCount;
-
-		std::vector<std::string> devNames = std::vector<std::string>(33);
-		std::vector<std::string> trackNames = std::vector<std::string>(64);
-		std::vector<int> devices = std::vector<int>(64);
-		std::vector<int> busses = std::vector<int>(64);
-		std::vector<int> pgms = std::vector<int>(64);
-		std::vector<int> trVelos = std::vector<int>(64);
-		std::vector<int> status = std::vector<int>(64);
-		std::vector<char> saveBytes;
-
-	private:
-		void parseNames(std::vector<char> loadBytes);
-		mpc::Mpc& mpc;
-
-	public:
-		std::string getDefaultSeqName();
-		int getTempo();
-		int getTimeSigNum();
-		int getTimeSigDen();
-		int getBarCount();
-		std::vector<std::string> getDefaultDevNames();
-		std::vector<std::string> getDefaultTrackNames();
-		std::vector<int> getDevices();
-		std::vector<int> getBusses();
-		std::vector<int> getPgms();
-		std::vector<int> getTrVelos();
-
-	private:
-		void setTrackSettings();
-		void setLastTick();
-		void setBarCount();
-		void setTimeSig();
-
-	public:
-		void setNames();
-		void setTempo();
-
-	public:
-		std::vector<char> getBytes();
-
-		Defaults(mpc::Mpc& mpc, const std::vector<char>& loadBytes);
-		Defaults(mpc::Mpc& mpc);
-	};
+class Defaults
+{
+    
+public:
+    static const int DEF_SEQ_NAME_OFFSET{ 0 };
+    static const int UNKNOWN1_OFFSET{ 16 };
+    static std::vector<char> UNKNOWN1;
+    
+public:
+    static const int TEMPO_BYTE1_OFFSET{ 22 };
+    static const int TEMPO_BYTE2_OFFSET{ 23 };
+    static const int TIMESIG_NUM_OFFSET{ 24 };
+    static const int TIMESIG_DEN_OFFSET{ 25 };
+    static const int BAR_COUNT_BYTE1_OFFSET{ 26 };
+    static const int BAR_COUNT_BYTE2_OFFSET{ 27 };
+    static const int LAST_TICK_BYTE1_OFFSET{ 28 };
+    static const int LAST_TICK_BYTE2_OFFSET{ 29 };
+    static const int LAST_TICK_BYTE3_OFFSET{ 30 };
+    static const int UNKNOWN32_BIT_INT_OFFSET{ 32 };
+    static const int UNKNOWN2_OFFSET{ 48 };
+    static std::vector<char> UNKNOWN2;
+    
+public:
+    static const int DEV_NAMES_OFFSET{ 120 };
+    static const int DEV_NAMES_LENGTH{ 264 };
+    static const int TR_NAMES_OFFSET{ 384 };
+    static const int TR_NAMES_LENGTH{ 1024 };
+    static const int DEVICES_OFFSET{ 1408 };
+    static const int DEVICES_LENGTH{ 64 };
+    static const int BUSSES_OFFSET{ 1472 };
+    static const int BUSSES_LENGTH{ 64 };
+    static const int PGMS_OFFSET{ 1536 };
+    static const int PGMS_LENGTH{ 64 };
+    static const int TR_VELOS_OFFSET{ 1600 };
+    static const int TR_VELOS_LENGTH{ 64 };
+    static const int TR_STATUS_OFFSET{ 1664 };
+    static const int TR_STATUS_LENGTH{ 64 };
+    
+    std::string defaultSeqName = "";
+    int tempo;
+    int timeSigNum;
+    int timeSigDen;
+    int barCount;
+    
+    std::vector<std::string> devNames = std::vector<std::string>(33);
+    std::vector<std::string> trackNames = std::vector<std::string>(64);
+    std::vector<int> devices = std::vector<int>(64);
+    std::vector<int> busses = std::vector<int>(64);
+    std::vector<int> pgms = std::vector<int>(64);
+    std::vector<int> trVelos = std::vector<int>(64);
+    std::vector<int> status = std::vector<int>(64);
+    std::vector<char> saveBytes;
+    
+private:
+    void parseNames(std::vector<char> loadBytes);
+    mpc::Mpc& mpc;
+    
+public:
+    std::string getDefaultSeqName();
+    int getTempo();
+    int getTimeSigNum();
+    int getTimeSigDen();
+    int getBarCount();
+    std::vector<std::string> getDefaultDevNames();
+    std::vector<std::string> getDefaultTrackNames();
+    std::vector<int> getDevices();
+    std::vector<int> getBusses();
+    std::vector<int> getPgms();
+    std::vector<int> getTrVelos();
+    
+private:
+    void setTrackSettings();
+    void setLastTick();
+    void setBarCount();
+    void setTimeSig();
+    
+public:
+    void setNames();
+    void setTempo();
+    
+public:
+    std::vector<char> getBytes();
+    
+    Defaults(mpc::Mpc& mpc, const std::vector<char>& loadBytes);
+    Defaults(mpc::Mpc& mpc);
+};
 }

--- a/src/main/file/all/Defaults.hpp
+++ b/src/main/file/all/Defaults.hpp
@@ -88,7 +88,7 @@ public:
     void setTempo();
     
 public:
-    std::vector<char> getBytes();
+    std::vector<char>& getBytes();
     
     Defaults(mpc::Mpc& mpc, const std::vector<char>& loadBytes);
     Defaults(mpc::Mpc& mpc);

--- a/src/main/file/all/Header.cpp
+++ b/src/main/file/all/Header.cpp
@@ -7,9 +7,9 @@
 using namespace mpc::file::all;
 using namespace std;
 
-Header::Header(const vector<char>& b) 
+Header::Header(const vector<char>& _loadBytes)
+: loadBytes (_loadBytes)
 {
-	loadBytes = b;
 }
 
 Header::Header()
@@ -20,7 +20,7 @@ Header::Header()
 		saveBytes[i] = s[i];
 }
 
-vector<char> Header::getHeaderArray()
+vector<char>& Header::getHeaderArray()
 {
     return loadBytes;
 }
@@ -41,7 +41,7 @@ bool Header::verifyFileID()
 	return verifyFileID;
 }
 
-vector<char> Header::getBytes()
+vector<char>& Header::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/Header.hpp
+++ b/src/main/file/all/Header.hpp
@@ -10,13 +10,13 @@ public:
     std::vector<char> saveBytes;
     
 public:
-    std::vector<char> getHeaderArray();
+    std::vector<char>& getHeaderArray();
     bool verifyFileID();
     
 public:
-    std::vector<char> getBytes();
+    std::vector<char>& getBytes();
     
-    Header(const std::vector<char>& b);
+    Header(const std::vector<char>& loadBytes);
     Header();
 };
 }

--- a/src/main/file/all/MidiInput.cpp
+++ b/src/main/file/all/MidiInput.cpp
@@ -68,20 +68,6 @@ MidiInput::MidiInput(mpc::Mpc& mpc)
 }
 
 vector<char> MidiInput::TEMPLATE = vector<char>{ 127, 64, 1, 0, 1, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 1, 0, 0, 0, 0, 0 };
-const int MidiInput::LENGTH;
-const int MidiInput::RECEIVE_CH_OFFSET;
-const int MidiInput::SUSTAIN_PEDAL_TO_DURATION_OFFSET;
-const int MidiInput::FILTER_ENABLED_OFFSET;
-const int MidiInput::FILTER_TYPE_OFFSET;
-const int MidiInput::MULTI_REC_ENABLED_OFFSET;
-const int MidiInput::MULTI_REC_TRACK_DESTS_OFFSET;
-const int MidiInput::MULTI_REC_TRACK_DESTS_LENGTH;
-const int MidiInput::NOTE_PASS_ENABLED_OFFSET;
-const int MidiInput::PITCH_BEND_PASS_ENABLED_OFFSET;
-const int MidiInput::PGM_CHANGE_PASS_ENABLED_OFFSET;
-const int MidiInput::CH_PRESSURE_PASS_ENABLED_OFFSET;
-const int MidiInput::POLY_PRESSURE_PASS_ENABLED_OFFSET;
-const int MidiInput::EXCLUSIVE_PASS_ENABLED_OFFSET;
 
 int MidiInput::getReceiveCh()
 {
@@ -143,7 +129,7 @@ bool MidiInput::isExclusivePassEnabled()
     return exclusivePassEnabled;
 }
 
-vector<char> MidiInput::getBytes()
+vector<char>& MidiInput::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/MidiInput.hpp
+++ b/src/main/file/all/MidiInput.hpp
@@ -7,60 +7,60 @@ namespace mpc { class Mpc; }
 
 namespace mpc::file::all {
 
-	class MidiInput
-	{
-
-	private:
-		static std::vector<char> TEMPLATE;
-
-	public:
-		static const int LENGTH{ 48 };
-		static const int RECEIVE_CH_OFFSET{ 3 };
-		static const int SUSTAIN_PEDAL_TO_DURATION_OFFSET{ 4 };
-		static const int FILTER_ENABLED_OFFSET{ 5 };
-		static const int FILTER_TYPE_OFFSET{ 6 };
-		static const int MULTI_REC_ENABLED_OFFSET{ 7 };
-		static const int MULTI_REC_TRACK_DESTS_OFFSET{ 8 };
-		static const int MULTI_REC_TRACK_DESTS_LENGTH{ 34 };
-		static const int NOTE_PASS_ENABLED_OFFSET{ 42 };
-		static const int PITCH_BEND_PASS_ENABLED_OFFSET{ 43 };
-		static const int PGM_CHANGE_PASS_ENABLED_OFFSET{ 44 };
-		static const int CH_PRESSURE_PASS_ENABLED_OFFSET{ 45 };
-		static const int POLY_PRESSURE_PASS_ENABLED_OFFSET{ 46 };
-		static const int EXCLUSIVE_PASS_ENABLED_OFFSET{ 47 };
-		int receiveCh{};
-		bool sustainPedalToDuration{};
-		bool filterEnabled{};
-		int filterType{};
-		bool multiRecEnabled{};
-		std::vector<int> multiRecTrackDests = std::vector<int>(34);
-		bool notePassEnabled{};
-		bool pitchBendPassEnabled{};
-		bool pgmChangePassEnabled{};
-		bool chPressurePassEnabled{};
-		bool polyPressurePassEnabled{};
-		bool exclusivePassEnabled{};
-		std::vector<char> saveBytes{};
-
-	public:
-		int getReceiveCh();
-		bool isSustainPedalToDurationEnabled();
-		bool isFilterEnabled();
-		int getFilterType();
-		bool isMultiRecEnabled();
-		std::vector<int> getMultiRecTrackDests();
-		bool isNotePassEnabled();
-		bool isPitchBendPassEnabled();
-		bool isPgmChangePassEnabled();
-		bool isChPressurePassEnabled();
-		bool isPolyPressurePassEnabled();
-		bool isExclusivePassEnabled();
-
-	public:
-		std::vector<char> getBytes();
-
-		MidiInput(const std::vector<char>& b);
-		MidiInput(mpc::Mpc& mpc);
-
-	};
+class MidiInput
+{
+    
+private:
+    static std::vector<char> TEMPLATE;
+    
+public:
+    static const int LENGTH{ 48 };
+    static const int RECEIVE_CH_OFFSET{ 3 };
+    static const int SUSTAIN_PEDAL_TO_DURATION_OFFSET{ 4 };
+    static const int FILTER_ENABLED_OFFSET{ 5 };
+    static const int FILTER_TYPE_OFFSET{ 6 };
+    static const int MULTI_REC_ENABLED_OFFSET{ 7 };
+    static const int MULTI_REC_TRACK_DESTS_OFFSET{ 8 };
+    static const int MULTI_REC_TRACK_DESTS_LENGTH{ 34 };
+    static const int NOTE_PASS_ENABLED_OFFSET{ 42 };
+    static const int PITCH_BEND_PASS_ENABLED_OFFSET{ 43 };
+    static const int PGM_CHANGE_PASS_ENABLED_OFFSET{ 44 };
+    static const int CH_PRESSURE_PASS_ENABLED_OFFSET{ 45 };
+    static const int POLY_PRESSURE_PASS_ENABLED_OFFSET{ 46 };
+    static const int EXCLUSIVE_PASS_ENABLED_OFFSET{ 47 };
+    int receiveCh;
+    bool sustainPedalToDuration;
+    bool filterEnabled;
+    int filterType;
+    bool multiRecEnabled;
+    std::vector<int> multiRecTrackDests = std::vector<int>(34);
+    bool notePassEnabled;
+    bool pitchBendPassEnabled;
+    bool pgmChangePassEnabled;
+    bool chPressurePassEnabled;
+    bool polyPressurePassEnabled;
+    bool exclusivePassEnabled;
+    std::vector<char> saveBytes;
+    
+public:
+    int getReceiveCh();
+    bool isSustainPedalToDurationEnabled();
+    bool isFilterEnabled();
+    int getFilterType();
+    bool isMultiRecEnabled();
+    std::vector<int> getMultiRecTrackDests();
+    bool isNotePassEnabled();
+    bool isPitchBendPassEnabled();
+    bool isPgmChangePassEnabled();
+    bool isChPressurePassEnabled();
+    bool isPolyPressurePassEnabled();
+    bool isExclusivePassEnabled();
+    
+public:
+    std::vector<char> getBytes();
+    
+    MidiInput(const std::vector<char>& b);
+    MidiInput(mpc::Mpc& mpc);
+    
+};
 }

--- a/src/main/file/all/MidiInput.hpp
+++ b/src/main/file/all/MidiInput.hpp
@@ -57,7 +57,7 @@ public:
     bool isExclusivePassEnabled();
     
 public:
-    std::vector<char> getBytes();
+    std::vector<char>& getBytes();
     
     MidiInput(const std::vector<char>& b);
     MidiInput(mpc::Mpc& mpc);

--- a/src/main/file/all/MidiSyncMisc.cpp
+++ b/src/main/file/all/MidiSyncMisc.cpp
@@ -53,16 +53,6 @@ MidiSyncMisc::MidiSyncMisc(mpc::Mpc& mpc)
 	saveBytes[DEF_SONG_NAME_OFFSET + 16] = 1;
 }
 
-const int MidiSyncMisc::LENGTH;
-const int MidiSyncMisc::IN_MODE_OFFSET;
-const int MidiSyncMisc::OUT_MODE_OFFSET;
-const int MidiSyncMisc::SHIFT_EARLY_OFFSET;
-const int MidiSyncMisc::SEND_MMC_OFFSET;
-const int MidiSyncMisc::FRAME_RATE_OFFSET;
-const int MidiSyncMisc::INPUT_OFFSET;
-const int MidiSyncMisc::OUTPUT_OFFSET;
-const int MidiSyncMisc::DEF_SONG_NAME_OFFSET;
-
 int MidiSyncMisc::getInMode()
 {
     return inMode;
@@ -103,7 +93,7 @@ string MidiSyncMisc::getDefSongName()
     return defSongName;
 }
 
-vector<char> MidiSyncMisc::getBytes()
+vector<char>& MidiSyncMisc::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/MidiSyncMisc.hpp
+++ b/src/main/file/all/MidiSyncMisc.hpp
@@ -8,48 +8,48 @@ namespace mpc { class Mpc; }
 
 namespace mpc::file::all
 {
-	class MidiSyncMisc
-	{
-
-	public:
-		static const int LENGTH{ 32 };
-
-	private:
-		static const int IN_MODE_OFFSET{ 0 };
-		static const int OUT_MODE_OFFSET{ 1 };
-		static const int SHIFT_EARLY_OFFSET{ 2 };
-		static const int SEND_MMC_OFFSET{ 3 };
-		static const int FRAME_RATE_OFFSET{ 4 };
-		static const int INPUT_OFFSET{ 5 };
-		static const int OUTPUT_OFFSET{ 6 };
-		static const int DEF_SONG_NAME_OFFSET{ 7 };
-
-	public:
-		int inMode;
-		int outMode;
-		int shiftEarly;
-		bool sendMMCEnabled;
-		int frameRate;
-		int input;
-		int output;
-		std::string defSongName{ "" };
-		std::vector<char> saveBytes;
-
-	public:
-		int getInMode();
-		int getOutMode();
-		int getShiftEarly();
-		bool isSendMMCEnabled();
-		int getFrameRate();
-		int getInput();
-		int getOutput();
-		std::string getDefSongName();
-
-	public:
-		std::vector<char> getBytes();
-
-		MidiSyncMisc(const std::vector<char>& b);
-		MidiSyncMisc(mpc::Mpc& mpc);
-
-	};
+class MidiSyncMisc
+{
+    
+public:
+    static const int LENGTH = 32;
+    
+private:
+    static const int IN_MODE_OFFSET = 0;
+    static const int OUT_MODE_OFFSET = 1;
+    static const int SHIFT_EARLY_OFFSET = 2;
+    static const int SEND_MMC_OFFSET = 3;
+    static const int FRAME_RATE_OFFSET = 4;
+    static const int INPUT_OFFSET = 5;
+    static const int OUTPUT_OFFSET = 6;
+    static const int DEF_SONG_NAME_OFFSET = 7;
+    
+public:
+    int inMode;
+    int outMode;
+    int shiftEarly;
+    bool sendMMCEnabled;
+    int frameRate;
+    int input;
+    int output;
+    std::string defSongName{ "" };
+    std::vector<char> saveBytes;
+    
+public:
+    int getInMode();
+    int getOutMode();
+    int getShiftEarly();
+    bool isSendMMCEnabled();
+    int getFrameRate();
+    int getInput();
+    int getOutput();
+    std::string getDefSongName();
+    
+public:
+    std::vector<char>& getBytes();
+    
+    MidiSyncMisc(const std::vector<char>& b);
+    MidiSyncMisc(mpc::Mpc& mpc);
+    
+};
 }

--- a/src/main/file/all/Misc.cpp
+++ b/src/main/file/all/Misc.cpp
@@ -58,13 +58,6 @@ Misc::Misc(mpc::Mpc& mpc)
 	saveBytes[MIDI_PGM_CHANGE_TO_SEQ_OFFSET] = 0; // Unimplemented
 }
 
-const int Misc::TAP_AVG_OFFSET;
-const int Misc::MIDI_SYNC_IN_RECEIVE_MMC_OFFSET;
-const int Misc::AUTO_STEP_INCREMENT_OFFSET;
-const int Misc::DURATION_OF_REC_NOTES_OFFSET;
-const int Misc::DURATION_TC_PERCENTAGE_OFFSET;
-const int Misc::MIDI_PGM_CHANGE_TO_SEQ_OFFSET;
-
 int Misc::getTapAvg()
 {
     return tapAvg;
@@ -100,7 +93,7 @@ vector<pair<int, int>> Misc::getSwitches()
     return switches;
 }
 
-vector<char> Misc::getBytes()
+vector<char>& Misc::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/Misc.hpp
+++ b/src/main/file/all/Misc.hpp
@@ -20,7 +20,7 @@ public:
     int getDurationTcPercentage();
     bool isPgmChToSeqEnabled();
     
-    std::vector<char> getBytes();
+    std::vector<char>& getBytes();
     
     Misc(const std::vector<char>& b);
     Misc(mpc::Mpc&);

--- a/src/main/file/all/SequenceNames.cpp
+++ b/src/main/file/all/SequenceNames.cpp
@@ -79,16 +79,12 @@ SequenceNames::SequenceNames(mpc::Mpc& mpc)
 	}
 }
 
-const int SequenceNames::LENGTH;
-const int SequenceNames::ENTRY_LENGTH;
-const int SequenceNames::LAST_EVENT_INDEX_OFFSET;
-
-vector<string> SequenceNames::getNames()
+vector<string>& SequenceNames::getNames()
 {
     return names;
 }
 
-vector<char> SequenceNames::getBytes()
+vector<char>& SequenceNames::getBytes()
 {
     return saveBytes;
 }
@@ -102,9 +98,7 @@ int SequenceNames::getSegmentCount(mpc::sequencer::Sequence* seq)
 		auto t = track.lock();
 
 		if (t->getIndex() > 63)
-		{
 			break;
-		}
 
 		for (auto& e : t->getEvents())
 		{
@@ -125,5 +119,6 @@ int SequenceNames::getSegmentCount(mpc::sequencer::Sequence* seq)
 			}
 		}
 	}
+    
 	return segmentCount;
 }

--- a/src/main/file/all/SequenceNames.hpp
+++ b/src/main/file/all/SequenceNames.hpp
@@ -16,17 +16,17 @@ class SequenceNames
 {
     
 public:
-    static const int LENGTH{ 1782 };
-    static const int ENTRY_LENGTH{ 18 };
-    static const int LAST_EVENT_INDEX_OFFSET{ 16 };
+    static const int LENGTH = 1782;
+    static const int ENTRY_LENGTH = 18;
+    static const int LAST_EVENT_INDEX_OFFSET = 16;
     std::vector<std::string> names = std::vector<std::string>(99);
     std::vector<char> saveBytes;
     
 public:
-    std::vector<std::string> getNames();
+    std::vector<std::string>& getNames();
     
 public:
-    std::vector<char> getBytes();
+    std::vector<char>& getBytes();
     static int getSegmentCount(mpc::sequencer::Sequence* seq);
     
     SequenceNames(const std::vector<char>& b);

--- a/src/main/file/all/SequenceNames.hpp
+++ b/src/main/file/all/SequenceNames.hpp
@@ -4,33 +4,32 @@
 #include <string>
 
 namespace mpc {
-	class Mpc;
+class Mpc;
 }
 
 namespace mpc::sequencer {
-	class Sequence;
+class Sequence;
 }
 
 namespace mpc::file::all {
-
-	class SequenceNames
-	{
-
-	public:
-		static const int LENGTH{ 1782 };
-		static const int ENTRY_LENGTH{ 18 };
-		static const int LAST_EVENT_INDEX_OFFSET{ 16 };
-		std::vector<std::string> names = std::vector<std::string>(99);
-		std::vector<char> saveBytes{};
-
-	public:
-		std::vector<std::string> getNames();
-
-	public:
-		std::vector<char> getBytes();
-		static int getSegmentCount(mpc::sequencer::Sequence* seq);
-
-		SequenceNames(const std::vector<char>& b);
-		SequenceNames(mpc::Mpc& mpc);
-	};
+class SequenceNames
+{
+    
+public:
+    static const int LENGTH{ 1782 };
+    static const int ENTRY_LENGTH{ 18 };
+    static const int LAST_EVENT_INDEX_OFFSET{ 16 };
+    std::vector<std::string> names = std::vector<std::string>(99);
+    std::vector<char> saveBytes;
+    
+public:
+    std::vector<std::string> getNames();
+    
+public:
+    std::vector<char> getBytes();
+    static int getSegmentCount(mpc::sequencer::Sequence* seq);
+    
+    SequenceNames(const std::vector<char>& b);
+    SequenceNames(mpc::Mpc& mpc);
+};
 }

--- a/src/main/file/all/Tracks.cpp
+++ b/src/main/file/all/Tracks.cpp
@@ -17,13 +17,16 @@ using namespace std;
 
 Tracks::Tracks(const vector<char>& loadBytes)
 {
-	for (int i = 0; i < 64; i++) {
+	for (int i = 0; i < 64; i++)
+    {
 		busses[i] = loadBytes[BUSSES_OFFSET + i];
 		pgms[i] = loadBytes[PGMS_OFFSET + i];
 		veloRatios[i] = loadBytes[VELO_RATIOS_OFFSET + i];
 		auto offset = TRACK_NAMES_OFFSET + (i * AllParser::NAME_LENGTH);
 		string name = "";
-		for (char c : moduru::VecUtil::CopyOfRange(loadBytes, offset, offset + AllParser::NAME_LENGTH)) {
+        
+		for (char c : moduru::VecUtil::CopyOfRange(loadBytes, offset, offset + AllParser::NAME_LENGTH))
+        {
 			if (c == 0x00) break;
 			name.push_back(c);
 		}
@@ -36,22 +39,28 @@ Tracks::Tracks(const vector<char>& loadBytes)
 Tracks::Tracks(mpc::sequencer::Sequence* seq)
 {
 	saveBytes = vector<char>(AllSequence::TRACKS_LENGTH);
-	for (int i = 0; i < 64; i++) {
+	for (int i = 0; i < 64; i++)
+    {
 		auto t = seq->getTrack(i).lock();
-		for (auto j = 0; j < AllParser::NAME_LENGTH; j++) {
+        
+		for (auto j = 0; j < AllParser::NAME_LENGTH; j++)
+        {
 			auto offset = TRACK_NAMES_OFFSET + (i * AllParser::NAME_LENGTH);
 			string name = moduru::lang::StrUtil::padRight(t->getActualName(), " ", AllParser::NAME_LENGTH);
 			saveBytes[offset + j] = name[j];
 		}
-		saveBytes[BUSSES_OFFSET + i] = (t->getBus());
+		
+        saveBytes[BUSSES_OFFSET + i] = (t->getBus());
 		saveBytes[PGMS_OFFSET + i] = (t->getProgramChange());
 		saveBytes[VELO_RATIOS_OFFSET + i] = (t->getVelocityRatio());
 		auto status = t->isUsed() ? 7 : 6;
+        
 		if (t->isUsed() && !t->isOn())
 			status = 5;
 
 		saveBytes[STATUS_OFFSET + i] = (status);
 	}
+    
 	for (int i = 0; i < PADDING1.size(); i++)
 		saveBytes[PADDING1_OFFSET + i] = PADDING1[i];
 
@@ -62,28 +71,21 @@ Tracks::Tracks(mpc::sequencer::Sequence* seq)
 	saveBytes[LAST_TICK_BYTE1_OFFSET] = lastTickBytes[0];
 	saveBytes[LAST_TICK_BYTE2_OFFSET] = lastTickBytes[1];
 	saveBytes[LAST_TICK_BYTE3_OFFSET] = (large);
-	auto unknown32BitIntBytes1 = moduru::file::ByteUtil::uint2bytes(10000000);
+	
+    auto unknown32BitIntBytes1 = moduru::file::ByteUtil::uint2bytes(10000000);
 	auto unknown32BitIntBytes2 = moduru::file::ByteUtil::uint2bytes((int)(seq->getLastTick() * 5208.333333333333));
-	for (int j = 0; j < 4; j++) {
+    
+	for (int j = 0; j < 4; j++)
+    {
 		int offset = UNKNOWN32_BIT_INT_OFFSET + j;
 		saveBytes[offset] = unknown32BitIntBytes1[j];
 	}
-	for (int j = 0; j < 4; j++) {
+	
+    for (int j = 0; j < 4; j++)
 		saveBytes[UNKNOWN32_BIT_INT_OFFSET + j + 4] = unknown32BitIntBytes2[j];
-	}
 }
 
-const int Tracks::TRACK_NAMES_OFFSET;
-const int Tracks::BUSSES_OFFSET;
-const int Tracks::PGMS_OFFSET;
-const int Tracks::VELO_RATIOS_OFFSET;
-const int Tracks::STATUS_OFFSET;
-const int Tracks::PADDING1_OFFSET;
 vector<char> Tracks::PADDING1 = vector<char>{ (char) 232, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (char) 232, 3 };
-const int Tracks::LAST_TICK_BYTE1_OFFSET;
-const int Tracks::LAST_TICK_BYTE2_OFFSET;
-const int Tracks::LAST_TICK_BYTE3_OFFSET;
-const int Tracks::UNKNOWN32_BIT_INT_OFFSET;
 
 int Tracks::getBus(int i)
 {
@@ -110,7 +112,7 @@ int Tracks::getStatus(int i)
     return status[i];
 }
 
-vector<char> Tracks::getBytes()
+vector<char>& Tracks::getBytes()
 {
     return saveBytes;
 }

--- a/src/main/file/all/Tracks.cpp
+++ b/src/main/file/all/Tracks.cpp
@@ -35,7 +35,7 @@ Tracks::Tracks(const vector<char>& loadBytes)
 
 Tracks::Tracks(mpc::sequencer::Sequence* seq)
 {
-	saveBytes = vector<char>(Sequence::TRACKS_LENGTH);
+	saveBytes = vector<char>(AllSequence::TRACKS_LENGTH);
 	for (int i = 0; i < 64; i++) {
 		auto t = seq->getTrack(i).lock();
 		for (auto j = 0; j < AllParser::NAME_LENGTH; j++) {

--- a/src/main/file/all/Tracks.hpp
+++ b/src/main/file/all/Tracks.hpp
@@ -3,53 +3,46 @@
 #include <vector>
 #include <string>
 
-namespace mpc {
+namespace mpc::sequencer {
+class Sequence;
+}
 
-	namespace sequencer {
-		class Sequence;
-	}
-
-	namespace file {
-		namespace all {
-
-			class Tracks
-			{
-
-			private:
-				static const int TRACK_NAMES_OFFSET{ 0 };
-				static const int BUSSES_OFFSET{ 1088 };
-				static const int PGMS_OFFSET{ 1152 };
-				static const int VELO_RATIOS_OFFSET{ 1216 };
-				static const int STATUS_OFFSET{ 1280 };
-				static const int PADDING1_OFFSET{ 1408 };
-				static std::vector<char> PADDING1;
-				static const int LAST_TICK_BYTE1_OFFSET{ 1424 };
-				static const int LAST_TICK_BYTE2_OFFSET{ 1425 };
-				static const int LAST_TICK_BYTE3_OFFSET{ 1426 };
-				static const int UNKNOWN32_BIT_INT_OFFSET{ 1428 };
-				std::vector<int> busses = std::vector<int>(64);
-				std::vector<int> veloRatios = std::vector<int>(64);
-				std::vector<int> pgms = std::vector<int>(64);
-				std::vector<std::string> names = std::vector<std::string>(64);
-				std::vector<int> status = std::vector<int>(64);
-
-			public:
-				std::vector<char> saveBytes{};
-
-			public:
-				int getBus(int i);
-				int getVelo(int i);
-				int getPgm(int i);
-				std::string getName(int i);
-				int getStatus(int i);
-
-			public:
-				std::vector<char> getBytes();
-
-				Tracks(const std::vector<char>& loadBytes);
-				Tracks(mpc::sequencer::Sequence* seq);
-			};
-
-		}
-	}
+namespace mpc::file::all {
+class Tracks
+{
+    
+private:
+    static const int TRACK_NAMES_OFFSET{ 0 };
+    static const int BUSSES_OFFSET{ 1088 };
+    static const int PGMS_OFFSET{ 1152 };
+    static const int VELO_RATIOS_OFFSET{ 1216 };
+    static const int STATUS_OFFSET{ 1280 };
+    static const int PADDING1_OFFSET{ 1408 };
+    static std::vector<char> PADDING1;
+    static const int LAST_TICK_BYTE1_OFFSET{ 1424 };
+    static const int LAST_TICK_BYTE2_OFFSET{ 1425 };
+    static const int LAST_TICK_BYTE3_OFFSET{ 1426 };
+    static const int UNKNOWN32_BIT_INT_OFFSET{ 1428 };
+    std::vector<int> busses = std::vector<int>(64);
+    std::vector<int> veloRatios = std::vector<int>(64);
+    std::vector<int> pgms = std::vector<int>(64);
+    std::vector<std::string> names = std::vector<std::string>(64);
+    std::vector<int> status = std::vector<int>(64);
+    
+public:
+    std::vector<char> saveBytes{};
+    
+public:
+    int getBus(int i);
+    int getVelo(int i);
+    int getPgm(int i);
+    std::string getName(int i);
+    int getStatus(int i);
+    
+public:
+    std::vector<char>& getBytes();
+    
+    Tracks(const std::vector<char>& loadBytes);
+    Tracks(mpc::sequencer::Sequence* seq);
+};
 }

--- a/src/main/file/aps/ApsDrumConfiguration.hpp
+++ b/src/main/file/aps/ApsDrumConfiguration.hpp
@@ -7,10 +7,10 @@ class ApsDrumConfiguration
 {
     
 public:
-    int program{};
-    bool receivePgmChange{};
-    bool receiveMidiVolume{};
-    std::vector<char> saveBytes{};
+    int program;
+    bool receivePgmChange;
+    bool receiveMidiVolume;
+    std::vector<char> saveBytes;
     
 private:
     static std::vector<char> TEMPLATE;

--- a/src/main/file/sndreader/SndReader.cpp
+++ b/src/main/file/sndreader/SndReader.cpp
@@ -78,7 +78,7 @@ int SndReader::getNumberOfBeats()
     return sndHeaderReader->getNumberOfBeats();
 }
 
-void SndReader::getSampleData(vector<float>* dest)
+void SndReader::writeSampleData(vector<float>* dest)
 {
 	int length = sndHeaderReader->getNumberOfFrames();
 

--- a/src/main/file/sndreader/SndReader.hpp
+++ b/src/main/file/sndreader/SndReader.hpp
@@ -37,7 +37,7 @@ public:
     bool isLoopEnabled();
     int getTune();
     int getNumberOfBeats();
-    void getSampleData(std::vector<float>* dest);
+    void writeSampleData(std::vector<float>* dest);
     
 public:
     std::vector<char>& getSndFileArray();

--- a/src/main/lcdgui/screens/SecondSeqScreen.hpp
+++ b/src/main/lcdgui/screens/SecondSeqScreen.hpp
@@ -2,41 +2,41 @@
 #include <lcdgui/ScreenComponent.hpp>
 
 namespace mpc::disk {
-	class AllLoader;
+class AllLoader;
 }
 
 namespace mpc::file::all {
-	class Sequencer;
+class AllSequencer;
 }
 
 namespace mpc::sequencer {
-	class Sequencer;
+class Sequencer;
 }
 
 namespace mpc::lcdgui::screens
 {
-	class SecondSeqScreen
-		: public mpc::lcdgui::ScreenComponent
-	{
-
-	public:
-		void function(int i) override;
-		void turnWheel(int i) override;
-
-	public:
-		SecondSeqScreen(mpc::Mpc& mpc, const int layerIndex);
-
-		void open() override;
-
-	private:
-		int sq = 0;
-		
-		void setSq(int i);
-		void displaySq();
-		void displayFunctionKeys();
-
-		friend class mpc::sequencer::Sequencer;
-		friend class mpc::disk::AllLoader;
-		friend class mpc::file::all::Sequencer;
-	};
+class SecondSeqScreen
+: public mpc::lcdgui::ScreenComponent
+{
+    
+public:
+    void function(int i) override;
+    void turnWheel(int i) override;
+    
+public:
+    SecondSeqScreen(mpc::Mpc& mpc, const int layerIndex);
+    
+    void open() override;
+    
+private:
+    int sq = 0;
+    
+    void setSq(int i);
+    void displaySq();
+    void displayFunctionKeys();
+    
+    friend class mpc::sequencer::Sequencer;
+    friend class mpc::disk::AllLoader;
+    friend class mpc::file::all::AllSequencer;
+};
 }

--- a/src/main/lcdgui/screens/window/LoadASequenceFromAllScreen.cpp
+++ b/src/main/lcdgui/screens/window/LoadASequenceFromAllScreen.cpp
@@ -47,8 +47,7 @@ void LoadASequenceFromAllScreen::function(int i)
 		openScreen("mpc2000xl-all-file");
 		break;
 	case 4:
-		auto loadASequenceFromAllScreen = mpc.screens->get<LoadASequenceFromAllScreen>("load-a-sequence-from-all");
-		auto candidate = loadASequenceFromAllScreen->sequencesFromAllFile[sourceSeqIndex];
+		auto candidate = sequencesFromAllFile[sourceSeqIndex];
 
 		if (candidate)
 		{
@@ -62,12 +61,13 @@ void LoadASequenceFromAllScreen::function(int i)
 
 void LoadASequenceFromAllScreen::displayFile()
 {
-	auto loadASequenceFromAllScreen = mpc.screens->get<LoadASequenceFromAllScreen>("load-a-sequence-from-all");
 	findField("file").lock()->setTextPadded(sourceSeqIndex + 1, "0");
 
-	auto candidate = sourceSeqIndex < sequencesFromAllFile.size() ? loadASequenceFromAllScreen->sequencesFromAllFile[sourceSeqIndex] : shared_ptr<mpc::sequencer::Sequence>();
-	auto name = candidate ? candidate->getName() : "(Unused)";
-	findLabel("file0").lock()->setText("-" + name);
+    auto candidate = sequencesFromAllFile[sourceSeqIndex];
+	
+    auto name = candidate ? candidate->getName() : "(Unused)";
+	
+    findLabel("file0").lock()->setText("-" + name);
 }
 
 void LoadASequenceFromAllScreen::displayLoadInto()
@@ -79,10 +79,7 @@ void LoadASequenceFromAllScreen::displayLoadInto()
 
 void LoadASequenceFromAllScreen::setSourceSeqIndex(int i)
 {
-	auto loadASequenceFromAllScreen = mpc.screens->get<LoadASequenceFromAllScreen>("load-a-sequence-from-all");
-	const auto max = loadASequenceFromAllScreen->sequencesFromAllFile.size();
-
-	if (i < 0 || i >= max)
+	if (i < 0 || i >= sequencesFromAllFile.size())
 		return;
 
 	sourceSeqIndex = i;

--- a/src/main/lcdgui/screens/window/NameScreen.hpp
+++ b/src/main/lcdgui/screens/window/NameScreen.hpp
@@ -3,110 +3,113 @@
 
 namespace mpc::controls
 {
-	class BaseControls;
+class BaseControls;
 }
 
 namespace mpc::lcdgui
 {
-	class Underline;
+class Underline;
 }
 
 namespace mpc::lcdgui::screens
 {
-	class SaveScreen;
+class SaveScreen;
 }
 
 namespace mpc::lcdgui::screens::window
 {
-	class EditSoundScreen;
-	class KeepOrRetryScreen;
-	class SaveAllFileScreen;
-	class SaveAProgramScreen;
-	class SaveApsFileScreen;
-	class SequenceScreen;
-	class SongWindow;
-	class SoundScreen;
-	class AutoChromaticAssignmentScreen;
-	class DirectoryScreen;
-	class MidiOutputScreen;
-	class TrackScreen;
-	class SaveASequenceScreen;
-	class ProgramScreen;
-	class VmpcDirectToDiskRecorderScreen;
+class EditSoundScreen;
+class KeepOrRetryScreen;
+class SaveAllFileScreen;
+class SaveAProgramScreen;
+class SaveApsFileScreen;
+class SequenceScreen;
+class SongWindow;
+class SoundScreen;
+class AutoChromaticAssignmentScreen;
+class DirectoryScreen;
+class MidiOutputScreen;
+class TrackScreen;
+class SaveASequenceScreen;
+class SaveASoundScreen;
+class ProgramScreen;
+class VmpcDirectToDiskRecorderScreen;
 }
 
 namespace mpc::lcdgui::screens::dialog
 {
-	class CopySoundScreen;
-	class StereoToMonoScreen;
-	class MonoToStereoScreen;
-	class FileExistsScreen;
-	class ResampleScreen;
+class CopySoundScreen;
+class StereoToMonoScreen;
+class MonoToStereoScreen;
+class FileExistsScreen;
+class ResampleScreen;
 }
 
 namespace mpc::lcdgui::screens::window
 {
-	class NameScreen
-		: public mpc::lcdgui::ScreenComponent
-	{
+class NameScreen
+: public mpc::lcdgui::ScreenComponent
+{
+    
+public:
+    NameScreen(mpc::Mpc& mpc, const int layerIndex);
+    
+    void open() override;
+    void close() override;
+    
+    void left() override;
+    void right() override;
+    void turnWheel(int j) override;
+    void function(int i) override;
+    void pressEnter() override;
+    
+private:
+    void drawUnderline();
+    void initEditColors();
+    void resetNameScreen();
+    void saveName();
+    void displayName();
+    
+    std::weak_ptr<mpc::lcdgui::Underline> findUnderline();
+    
+private:
+    std::string name = "";
+    bool editing{ false };
+    std::string parameterName = "";
+    int nameLimit{ 0 };
+    std::string originalName = "";
+    
+private:
+    void setName(std::string name);
+    void setNameLimit(int i);
+    void setName(std::string str, int i);
+    std::string getName();
+    void changeNameCharacter(int i, bool up);
+    
+    friend class mpc::controls::BaseControls;
 
-	public:
-		NameScreen(mpc::Mpc& mpc, const int layerIndex);
-
-		void open() override;
-		void close() override;
-
-		void left() override;
-		void right() override;
-		void turnWheel(int j) override;
-		void function(int i) override;
-		void pressEnter() override;
-
-	private:
-		void drawUnderline();
-		void initEditColors();
-		void resetNameScreen();
-		void saveName();
-		void displayName();
-
-		std::weak_ptr<mpc::lcdgui::Underline> findUnderline();
-
-	private:
-		std::string name = "";
-		bool editing{ false };
-		std::string parameterName = "";
-		int nameLimit{ 0 };
-		std::string originalName = "";
-
-	private:
-		void setName(std::string name);
-		void setNameLimit(int i);
-		void setName(std::string str, int i);
-		std::string getName();
-		void changeNameCharacter(int i, bool up);
-
-		friend class EditSoundScreen;
-		friend class KeepOrRetryScreen;
-		friend class SaveAllFileScreen;
-		friend class SaveAProgramScreen;
-		friend class SaveApsFileScreen;
-		friend class mpc::controls::BaseControls;
-		friend class mpc::lcdgui::screens::window::VmpcDirectToDiskRecorderScreen;
-		friend class mpc::lcdgui::screens::dialog::CopySoundScreen;
-		friend class mpc::lcdgui::screens::dialog::StereoToMonoScreen;
-		friend class mpc::lcdgui::screens::dialog::MonoToStereoScreen;
-		friend class mpc::lcdgui::screens::dialog::FileExistsScreen;
-		friend class mpc::lcdgui::screens::dialog::ResampleScreen;
-		friend class SequenceScreen;
-		friend class SongWindow;
-		friend class SoundScreen;
-		friend class AutoChromaticAssignmentScreen;
-		friend class DirectoryScreen;
-		friend class MidiOutputScreen;
-		friend class TrackScreen;
-		friend class SaveASequenceScreen;
-		friend class ProgramScreen;
-		friend class mpc::lcdgui::screens::SaveScreen;
-
-	};
+    friend class EditSoundScreen;
+    friend class KeepOrRetryScreen;
+    friend class SaveAllFileScreen;
+    friend class SaveAProgramScreen;
+    friend class SaveApsFileScreen;
+    friend class SaveASoundScreen;
+    friend class VmpcDirectToDiskRecorderScreen;
+    friend class mpc::lcdgui::screens::dialog::CopySoundScreen;
+    friend class mpc::lcdgui::screens::dialog::StereoToMonoScreen;
+    friend class mpc::lcdgui::screens::dialog::MonoToStereoScreen;
+    friend class mpc::lcdgui::screens::dialog::FileExistsScreen;
+    friend class mpc::lcdgui::screens::dialog::ResampleScreen;
+    friend class SequenceScreen;
+    friend class SongWindow;
+    friend class SoundScreen;
+    friend class AutoChromaticAssignmentScreen;
+    friend class DirectoryScreen;
+    friend class MidiOutputScreen;
+    friend class TrackScreen;
+    friend class SaveASequenceScreen;
+    friend class ProgramScreen;
+    friend class mpc::lcdgui::screens::SaveScreen;
+    
+};
 }

--- a/src/main/lcdgui/screens/window/SaveASoundScreen.cpp
+++ b/src/main/lcdgui/screens/window/SaveASoundScreen.cpp
@@ -1,5 +1,7 @@
 #include "SaveASoundScreen.hpp"
 
+#include <lcdgui/screens/window/NameScreen.hpp>
+
 #include <disk/AbstractDisk.hpp>
 #include <Util.hpp>
 
@@ -13,12 +15,6 @@ SaveASoundScreen::SaveASoundScreen(mpc::Mpc& mpc, const int layerIndex)
 
 void SaveASoundScreen::open()
 {
-	if (ls.lock()->getPreviousScreenName().compare("name") != 0)
-	{
-		if (sampler.lock()->getSound().lock())
-			saveName = sampler.lock()->getSound().lock()->getName();
-	}
-
 	displayFile();
 	displayFileType();
 }
@@ -30,19 +26,22 @@ void SaveASoundScreen::turnWheel(int i)
 	if (param.compare("file") == 0 && i > 0)
 	{
 		sampler.lock()->selectPreviousSound();
-		saveName = sampler.lock()->getSound().lock()->getName();
-		displayFile();
 	}
 	else if (param.compare("file") == 0 && i < 0)
 	{
 		sampler.lock()->selectNextSound();
-		saveName = sampler.lock()->getSound().lock()->getName();
-		displayFile();
 	}
 	else if (param.compare("file-type") == 0)
 	{
 		setFileType(fileType + i);
 	}
+    
+    if (param.compare("file") == 0)
+    {
+        auto saveName = sampler.lock()->getSound().lock()->getName();
+        mpc.screens->get<NameScreen>("name")->setName(saveName);
+        displayFile();
+    }
 }
 
 void SaveASoundScreen::function(int i)
@@ -59,7 +58,7 @@ void SaveASoundScreen::function(int i)
 		auto disk = mpc.getDisk().lock();
 		auto s = sampler.lock()->getSound().lock();
 		auto ext = string(fileType == 0 ? ".SND" : ".WAV");
-		auto fileName = mpc::Util::getFileName(saveName) + ext;
+		auto fileName = mpc::Util::getFileName(mpc.screens->get<NameScreen>("name")->getName()) + ext;
 
 		if (disk->checkExists(fileName))
 		{
@@ -101,5 +100,5 @@ void SaveASoundScreen::displayFileType()
 
 void SaveASoundScreen::displayFile()
 {
-	findField("file").lock()->setText(saveName);
+	findField("file").lock()->setText(mpc.screens->get<NameScreen>("name")->getName());
 }

--- a/src/main/lcdgui/screens/window/SaveASoundScreen.hpp
+++ b/src/main/lcdgui/screens/window/SaveASoundScreen.hpp
@@ -3,30 +3,29 @@
 
 namespace mpc::lcdgui::screens::dialog
 {
-	class FileExistsScreen;
+class FileExistsScreen;
 }
 
 namespace mpc::lcdgui::screens::window
 {
-	class SaveASoundScreen
-		: public mpc::lcdgui::ScreenComponent
-	{
-
-	public:
-		void turnWheel(int i) override;
-		void function(int i) override;
-
-		SaveASoundScreen(mpc::Mpc& mpc, const int layerIndex);
-		void open() override;
-
-	private:
-		std::string saveName = "";
-		void setFileType(int i);
-		int fileType = 0;
-		void displayFileType();
-		void displayFile();
-
-		friend class mpc::lcdgui::screens::dialog::FileExistsScreen;
-
-	};
+class SaveASoundScreen
+: public mpc::lcdgui::ScreenComponent
+{
+    
+public:
+    void turnWheel(int i) override;
+    void function(int i) override;
+    
+    SaveASoundScreen(mpc::Mpc& mpc, const int layerIndex);
+    void open() override;
+    
+private:
+    void setFileType(int i);
+    int fileType = 0;
+    void displayFileType();
+    void displayFile();
+    
+    friend class mpc::lcdgui::screens::dialog::FileExistsScreen;
+    
+};
 }

--- a/src/main/sequencer/Sequence.cpp
+++ b/src/main/sequencer/Sequence.cpp
@@ -1,4 +1,4 @@
-#include <sequencer/Sequence.hpp>
+#include "Sequence.hpp"
 
 #include <Mpc.hpp>
 
@@ -22,11 +22,9 @@ using namespace mpc::lcdgui::screens::dialog;
 using namespace mpc::sequencer;
 using namespace std;
 
-Sequence::Sequence(mpc::Mpc& mpc, vector<string> defaultTrackNames)
-	: mpc(mpc)
+Sequence::Sequence(mpc::Mpc& _mpc)
+	: mpc (_mpc), defaultTrackNames (_mpc.getSequencer().lock()->getDefaultTrackNames())
 {
-	this->defaultTrackNames = defaultTrackNames;
-
 	for (int i = 0; i < 64; i++)
 	{
 		tracks.push_back(make_shared<Track>(mpc, this, i));

--- a/src/main/sequencer/Sequence.hpp
+++ b/src/main/sequencer/Sequence.hpp
@@ -7,121 +7,121 @@
 namespace mpc { class Mpc; }
 
 namespace mpc::sequencer {
-	class Track;
-	class TimeSignature;
-	class TempoChangeEvent;
+class Track;
+class TimeSignature;
+class TempoChangeEvent;
 }
 
 namespace mpc::sequencer {
 
-	class Sequence final
-		: public moduru::observer::Observable
-	{
-
-	private:
-		mpc::Mpc& mpc;
-		double initialTempo = 120.0;
-
-		std::vector<std::shared_ptr<Track>> tracks;
-        std::vector<std::weak_ptr<Track>> weakTracks;
-		std::vector<std::shared_ptr<Track>> metaTracks;
-        std::vector<std::weak_ptr<Track>> weakMetaTracks;
-        
-		std::vector<std::string> deviceNames = std::vector<std::string>(33);
-		std::vector<std::string> defaultTrackNames;
-
-		std::vector<int> barLengths = std::vector<int>(999);
-		std::vector<int> numerators = std::vector<int>(999);
-		std::vector<int> denominators = std::vector<int>(999);
-
-		std::string name = "";
-		bool loopEnabled = true;
-		int lastBarIndex = -1;
-		bool used = false;
-		bool tempoChangeOn = true;
-		int loopStart = 0;
-		int loopEnd = 0;
-		int firstLoopBarIndex = 0;
-		int lastLoopBarIndex = 0;
-		bool lastLoopBarEnd = true;
-
-	public:
-		double getInitialTempo();
-		void setInitialTempo(const double initialTempo);
-
-		void setLoopStart(int l);
-		int getLoopStart();
-		void setLoopEnd(int l);
-		int getLoopEnd();
-		void setFirstLoopBarIndex(int i);
-		int getFirstLoopBarIndex();
-		void setLastLoopBarIndex(int i);
-		int getLastLoopBarIndex();
-		void initMetaTracks();
-
-	public:
-		void createClickTrack();
-		void createMidiClockTrack();
-		void createTempoChangeTrack();
-
-		static bool trackIndexComparator(std::weak_ptr<Track> t0, std::weak_ptr<Track> t1);
-
-	public:
-		bool isLoopEnabled();
-		void setName(std::string s);
-		std::string getName();
-		void setDeviceName(int i, std::string s);
-		std::string getDeviceName(int i);
-		void setLastBar(int i);
-		int getLastBarIndex();
-		void setLoopEnabled(bool b);
-		std::weak_ptr<Track> getTrack(int i);
-		void setUsed(bool b);
-		bool isUsed();
-		void init(int lastBarIndex);
-		void setTimeSignature(int firstBar, int tsLastBar, int num, int den);
-		void setTimeSignature(int bar, int num, int den);
-		std::vector<std::weak_ptr<Track>> getTracks();
-		std::vector<std::weak_ptr<Track>> getMetaTracks();
-		std::vector<std::string> getDeviceNames();
-		void setDeviceNames(std::vector<std::string> sa);
-		std::vector<std::weak_ptr<TempoChangeEvent>> getTempoChangeEvents();
-		std::weak_ptr<TempoChangeEvent> addTempoChangeEvent();
-		void removeTempoChangeEvent(int i);
-		void removeTempoChangeEvent(std::weak_ptr<TempoChangeEvent> tce);
-
-		bool isTempoChangeOn();
-		void setTempoChangeOn(bool b);
-		int getLastTick();
-		TimeSignature getTimeSignature();
-		void sortTempoChangeEvents();
-		void purgeAllTracks();
-		std::weak_ptr<Track> purgeTrack(int i);
-		int getDenominator(int i);
-		int getNumerator(int i);
-		std::vector<int>* getBarLengths();
-		void setBarLengths(std::vector<int>&);
-		void setNumeratorsAndDenominators(std::vector<int>& numerators, std::vector<int>& denominators);
-		void deleteBars(int firstBar, int lBar);
-		void insertBars(int numberOfBars, int afterBar);
-		void moveTrack(int source, int destination);
-		bool isLastLoopBarEnd();
-
-		int getEventCount();
-		void initLoop();
-		std::vector<int>* getNumerators();
-		std::vector<int>* getDenominators();
-		void removeFirstMetronomeClick();
-		int getNoteEventCount();
-
-		int getFirstTickOfBar(int index);
-		int getLastTickOfBar(int index);
-		int getFirstTickOfBeat(int bar, int beat);
-
-		void resetTrackEventIndices(int tick);
-
-	public:
-		Sequence(mpc::Mpc& mpc, std::vector<std::string> defaultTrackNames);
-
-	};
+class Sequence final
+: public moduru::observer::Observable
+{
+    
+private:
+    mpc::Mpc& mpc;
+    double initialTempo = 120.0;
+    
+    std::vector<std::shared_ptr<Track>> tracks;
+    std::vector<std::weak_ptr<Track>> weakTracks;
+    std::vector<std::shared_ptr<Track>> metaTracks;
+    std::vector<std::weak_ptr<Track>> weakMetaTracks;
+    
+    std::vector<std::string> deviceNames = std::vector<std::string>(33);
+    std::vector<std::string> defaultTrackNames;
+    
+    std::vector<int> barLengths = std::vector<int>(999);
+    std::vector<int> numerators = std::vector<int>(999);
+    std::vector<int> denominators = std::vector<int>(999);
+    
+    std::string name = "";
+    bool loopEnabled = true;
+    int lastBarIndex = -1;
+    bool used = false;
+    bool tempoChangeOn = true;
+    int loopStart = 0;
+    int loopEnd = 0;
+    int firstLoopBarIndex = 0;
+    int lastLoopBarIndex = 0;
+    bool lastLoopBarEnd = true;
+    
+public:
+    double getInitialTempo();
+    void setInitialTempo(const double initialTempo);
+    
+    void setLoopStart(int l);
+    int getLoopStart();
+    void setLoopEnd(int l);
+    int getLoopEnd();
+    void setFirstLoopBarIndex(int i);
+    int getFirstLoopBarIndex();
+    void setLastLoopBarIndex(int i);
+    int getLastLoopBarIndex();
+    void initMetaTracks();
+    
+public:
+    void createClickTrack();
+    void createMidiClockTrack();
+    void createTempoChangeTrack();
+    
+    static bool trackIndexComparator(std::weak_ptr<Track> t0, std::weak_ptr<Track> t1);
+    
+public:
+    bool isLoopEnabled();
+    void setName(std::string s);
+    std::string getName();
+    void setDeviceName(int i, std::string s);
+    std::string getDeviceName(int i);
+    void setLastBar(int i);
+    int getLastBarIndex();
+    void setLoopEnabled(bool b);
+    std::weak_ptr<Track> getTrack(int i);
+    void setUsed(bool b);
+    bool isUsed();
+    void init(int lastBarIndex);
+    void setTimeSignature(int firstBar, int tsLastBar, int num, int den);
+    void setTimeSignature(int bar, int num, int den);
+    std::vector<std::weak_ptr<Track>> getTracks();
+    std::vector<std::weak_ptr<Track>> getMetaTracks();
+    std::vector<std::string> getDeviceNames();
+    void setDeviceNames(std::vector<std::string> sa);
+    std::vector<std::weak_ptr<TempoChangeEvent>> getTempoChangeEvents();
+    std::weak_ptr<TempoChangeEvent> addTempoChangeEvent();
+    void removeTempoChangeEvent(int i);
+    void removeTempoChangeEvent(std::weak_ptr<TempoChangeEvent> tce);
+    
+    bool isTempoChangeOn();
+    void setTempoChangeOn(bool b);
+    int getLastTick();
+    TimeSignature getTimeSignature();
+    void sortTempoChangeEvents();
+    void purgeAllTracks();
+    std::weak_ptr<Track> purgeTrack(int i);
+    int getDenominator(int i);
+    int getNumerator(int i);
+    std::vector<int>* getBarLengths();
+    void setBarLengths(std::vector<int>&);
+    void setNumeratorsAndDenominators(std::vector<int>& numerators, std::vector<int>& denominators);
+    void deleteBars(int firstBar, int lBar);
+    void insertBars(int numberOfBars, int afterBar);
+    void moveTrack(int source, int destination);
+    bool isLastLoopBarEnd();
+    
+    int getEventCount();
+    void initLoop();
+    std::vector<int>* getNumerators();
+    std::vector<int>* getDenominators();
+    void removeFirstMetronomeClick();
+    int getNoteEventCount();
+    
+    int getFirstTickOfBar(int index);
+    int getLastTickOfBar(int index);
+    int getFirstTickOfBeat(int bar, int beat);
+    
+    void resetTrackEventIndices(int tick);
+    
+public:
+    Sequence(mpc::Mpc&);
+    
+};
 }

--- a/src/main/sequencer/Sequencer.cpp
+++ b/src/main/sequencer/Sequencer.cpp
@@ -739,7 +739,7 @@ void Sequencer::purgeAllSequences()
 
 void Sequencer::purgeSequence(int i) {
 	sequences[i].reset();
-	auto sequence = make_shared<Sequence>(mpc, defaultTrackNames);
+	auto sequence = make_shared<Sequence>(mpc);
 	sequences[i].swap(sequence);
 	sequences[i]->resetTrackEventIndices(position);
 	string res = defaultSequenceName;
@@ -763,7 +763,7 @@ void Sequencer::copySequenceParameters(const int source, const int dest)
 shared_ptr<Sequence> Sequencer::copySequence(weak_ptr<Sequence> src)
 {
 	auto source = src.lock();
-	auto copy = make_shared<Sequence>(mpc, defaultTrackNames);
+	auto copy = make_shared<Sequence>(mpc);
 	copy->init(source->getLastBarIndex());
 	copySequenceParameters(source, copy);
 	
@@ -1624,7 +1624,7 @@ void Sequencer::playMetronomeTrack()
 	}
 
 	metronomeOnly = true;
-	metronomeSeq = make_unique<Sequence>(mpc, defaultTrackNames);
+	metronomeSeq = make_unique<Sequence>(mpc);
 	auto s = getActiveSequence().lock();
 	metronomeSeq->init(8);
 	metronomeSeq->setTimeSignature(0, 3, s->getNumerator(getCurrentBarIndex()), s->getDenominator(getCurrentBarIndex()));
@@ -1638,27 +1638,33 @@ void Sequencer::playMetronomeTrack()
 
 void Sequencer::stopMetronomeTrack()
 {
-	if (!metronomeOnly) return;
-	metronomeOnly = false;
+	if (!metronomeOnly)
+        return;
+	
+    metronomeOnly = false;
 	mpc.getAudioMidiServices().lock()->getFrameSequencer().lock()->stop();
 }
 
-weak_ptr<Sequence> Sequencer::createSeqInPlaceHolder() {
-	placeHolder = make_shared<Sequence>(mpc, defaultTrackNames);
+weak_ptr<Sequence> Sequencer::createSeqInPlaceHolder()
+{
+	placeHolder = make_shared<Sequence>(mpc);
 	return placeHolder;
 }
 
-void Sequencer::clearPlaceHolder() {
+void Sequencer::clearPlaceHolder()
+{
 	placeHolder.reset();
 }
 
-void Sequencer::movePlaceHolderTo(int destIndex) {
+void Sequencer::movePlaceHolderTo(int destIndex)
+{
 	sequences[destIndex].swap(placeHolder);
 	sequences[destIndex]->resetTrackEventIndices(position);
 	clearPlaceHolder();
 }
 
-weak_ptr<Sequence> Sequencer::getPlaceHolder() {
+weak_ptr<Sequence> Sequencer::getPlaceHolder()
+{
 	return placeHolder;
 }
 


### PR DESCRIPTION
Code cleanup. Also use a bit less memory during ALL loading by copying byte vectors only when necessary.