### PR TITLE
Fix pad note mixup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{c,cpp,h,hpp}]
+indent_size = 4

--- a/src/main/audiomidi/EventHandler.cpp
+++ b/src/main/audiomidi/EventHandler.cpp
@@ -168,7 +168,8 @@ void EventHandler::handleNoThru(weak_ptr<mpc::sequencer::Event> e, mpc::sequence
 					{
 						auto note = ne->getNote();
 						auto program = mpc.getSampler().lock()->getProgram(mpc.getDrum(drum)->getProgram());
-						int pad = program.lock()->getPadIndexFromNote(note);
+						
+                        int pad = program.lock()->getPadIndexFromNote(note);
 						int bank = mpc.getBank();
 						pad -= bank * 16;
 					

--- a/src/main/audiomidi/MpcMidiInput.cpp
+++ b/src/main/audiomidi/MpcMidiInput.cpp
@@ -270,7 +270,8 @@ void MpcMidiInput::transport(MidiMessage* msg, int timeStamp)
         
         auto pad = p->getPadIndexFromNote(note->getNote());
         
-        mpc.setPadAndNote(pad, note->getNote());
+        if (pad != -1)
+            mpc.setPadAndNote(pad, note->getNote());
         
         mpc.getEventHandler().lock()->handleNoThru(note, track.get(), timeStamp);
         

--- a/src/main/audiomidi/MpcMidiInput.cpp
+++ b/src/main/audiomidi/MpcMidiInput.cpp
@@ -206,6 +206,7 @@ void MpcMidiInput::transport(MidiMessage* msg, int timeStamp)
         {
             auto pgm = lSampler->getDrumBusProgramNumber(bus);
             auto p = lSampler->getProgram(pgm).lock();
+            
             auto pad = p->getPadIndexFromNote(note);
             
             if (pad != -1)
@@ -268,7 +269,9 @@ void MpcMidiInput::transport(MidiMessage* msg, int timeStamp)
         controls->setSliderNoteVar(note.get(), p);
         
         auto pad = p->getPadIndexFromNote(note->getNote());
+        
         mpc.setPadAndNote(pad, note->getNote());
+        
         mpc.getEventHandler().lock()->handleNoThru(note, track.get(), timeStamp);
         
         if (lSequencer->isRecordingOrOverdubbing())

--- a/src/main/lcdgui/MixerStrip.cpp
+++ b/src/main/lcdgui/MixerStrip.cpp
@@ -185,9 +185,10 @@ void MixerStrip::setValueAString(string str)
 	}
 	else if (mixerScreen->getTab() == 2)
 	{
-		findLabel("0").lock()->setText(str.substr(0, 1));
-		findLabel("1").lock()->setText(str.substr(1, 2));
+		findLabel("0").lock()->setText(str.length() > 0 ? str.substr(0, 1) : "");
+		findLabel("1").lock()->setText(str.length() > 1 ? str.substr(1, 2) : "");
 	}
+    
 	SetDirty();
 }
 

--- a/src/main/lcdgui/screens/MixerScreen.cpp
+++ b/src/main/lcdgui/screens/MixerScreen.cpp
@@ -77,7 +77,7 @@ shared_ptr<MpcStereoMixerChannel> MixerScreen::getStereoMixerChannel(int xPos)
     auto mixerSetupScreen = mpc.screens->get<MixerSetupScreen>("mixer-setup");
     bool stereoMixSourceIsDrum = mixerSetupScreen->isStereoMixSourceDrum();
     
-    return stereoMixSourceIsDrum ? mpcSoundPlayerChannel->getStereoMixerChannels()[padIndex].lock() : noteParameters->getStereoMixerChannel().lock();
+    return stereoMixSourceIsDrum ? mpcSoundPlayerChannel->getStereoMixerChannels()[note - 35].lock() : noteParameters->getStereoMixerChannel().lock();
 }
 
 shared_ptr<MpcIndivFxMixerChannel> MixerScreen::getIndivFxMixerChannel(int xPos)
@@ -93,7 +93,7 @@ shared_ptr<MpcIndivFxMixerChannel> MixerScreen::getIndivFxMixerChannel(int xPos)
     auto mixerSetupScreen = mpc.screens->get<MixerSetupScreen>("mixer-setup");
     bool indivFxSourceIsDrum = mixerSetupScreen->isIndivFxSourceDrum();
     
-    return indivFxSourceIsDrum ? mpcSoundPlayerChannel->getIndivFxMixerChannels()[padIndex].lock() : noteParameters->getIndivFxMixerChannel().lock();
+    return indivFxSourceIsDrum ? mpcSoundPlayerChannel->getIndivFxMixerChannels()[note - 35].lock() : noteParameters->getIndivFxMixerChannel().lock();
 }
 
 void MixerScreen::displayMixerStrip(int i)
@@ -106,8 +106,11 @@ void MixerScreen::displayMixerStrip(int i)
     
     if (!stereoMixer || !indivFxMixer)
     {
-        strip->findChild<Knob>("").lock()->Hide(true);
-        strip->setValueAString("");
+        if (tab == 0)
+            strip->findChild<Knob>("").lock()->Hide(true);
+        else
+            strip->setValueAString("");
+        
         strip->setValueB(0);
         return;
     }

--- a/src/main/lcdgui/screens/MixerScreen.hpp
+++ b/src/main/lcdgui/screens/MixerScreen.hpp
@@ -4,76 +4,84 @@
 
 #include <memory>
 
-namespace mpc::lcdgui::screens
-{
-	class SelectMixerDrumScreen;
+namespace mpc::lcdgui::screens {
+class SelectMixerDrumScreen;
 }
 
-namespace mpc::lcdgui::screens::window
-{
-	class ChannelSettingsScreen;
+namespace mpc::lcdgui::screens::window {
+class ChannelSettingsScreen;
+}
+
+namespace ctoot::mpc {
+class MpcStereoMixerChannel;
+class MpcIndivFxMixerChannel;
 }
 
 namespace mpc::lcdgui::screens
 {
-	class MixerScreen
-		: public mpc::lcdgui::ScreenComponent
-	{
-
-	public:
-		void function(int i) override;
-		void turnWheel(int i) override;
-		void up() override;
-		void down() override;
-		void left() override;
-		void right() override;
-		void openWindow() override;
-
-		MixerScreen(mpc::Mpc& mpc, const int layerIndex);
-
-		void open() override;
-		void close() override;
-
-	private:
-		void recordMixerEvent(int pad, int param, int value);
-
-	private:
-		const std::vector<std::string> fxPathNames{ "--", "M1", "M2", "R1", "R2" };
-		const std::vector<std::string> stereoNames{ "-", "12", "12", "34", "34", "56", "56", "78", "78" };
-		const std::vector<std::string> monoNames{ "-", "1", "2", "3", "4", "5", "6", "7", "8" };
-
-	private:
-		int tab = 0;
-		int lastTab = -1;
-		bool link = false;
-
-		int yPos = 0;
-		std::vector<std::weak_ptr<mpc::lcdgui::MixerStrip>> mixerStrips;
-		void addMixerStrips();
-		void displayMixerStrip(int i);
-		void displayMixerStrips();
-		void displayFunctionKeys();
-		void displayStereoFaders();
-		void displayIndivFaders();
-		void displayPanning();
-		void displayIndividualOutputs();
-		void displayFxPaths();
-		void displayFxSendLevels();
-
-		void setLink(bool b);
-		void setTab(int i);
-		void setYPos(int i);
-
-	public:
-		int getTab();
-		int getXPos();
-
-	public:
-		void update(moduru::observer::Observable* o, nonstd::any arg) override;
-
-	private:
-		friend class SelectMixerDrumScreen;
-		friend class mpc::lcdgui::screens::window::ChannelSettingsScreen;
-
-	};
+class MixerScreen
+: public mpc::lcdgui::ScreenComponent
+{
+    
+public:
+    void function(int i) override;
+    void turnWheel(int i) override;
+    void up() override;
+    void down() override;
+    void left() override;
+    void right() override;
+    void openWindow() override;
+    
+    MixerScreen(mpc::Mpc& mpc, const int layerIndex);
+    
+    void open() override;
+    void close() override;
+    
+private:
+    void recordMixerEvent(int pad, int param, int value);
+    void turnWheelLinked(int i);
+    
+private:
+    const std::vector<std::string> fxPathNames{ "--", "M1", "M2", "R1", "R2" };
+    const std::vector<std::string> stereoNames{ "-", "12", "12", "34", "34", "56", "56", "78", "78" };
+    const std::vector<std::string> monoNames{ "-", "1", "2", "3", "4", "5", "6", "7", "8" };
+    
+private:
+    int tab = 0;
+    int lastTab = -1;
+    bool link = false;
+    
+    int yPos = 0;
+    std::vector<std::weak_ptr<mpc::lcdgui::MixerStrip>> mixerStrips;
+    void addMixerStrips();
+    void displayMixerStrip(int i);
+    void displayMixerStrips();
+    void displayFunctionKeys();
+    void displayStereoFaders();
+    void displayIndivFaders();
+    void displayPanning();
+    void displayIndividualOutputs();
+    void displayFxPaths();
+    void displayFxSendLevels();
+    
+    std::shared_ptr<ctoot::mpc::MpcStereoMixerChannel> getStereoMixerChannel(int xPos);
+    
+    std::shared_ptr<ctoot::mpc::MpcIndivFxMixerChannel> getIndivFxMixerChannel(int xPos);
+    
+    void setLink(bool b);
+    void setTab(int i);
+    void setYPos(int i);
+    
+public:
+    int getTab();
+    int getXPos();
+    
+public:
+    void update(moduru::observer::Observable* o, nonstd::any arg) override;
+    
+private:
+    friend class SelectMixerDrumScreen;
+    friend class mpc::lcdgui::screens::window::ChannelSettingsScreen;
+    
+};
 }

--- a/src/main/lcdgui/screens/window/ChannelSettingsScreen.cpp
+++ b/src/main/lcdgui/screens/window/ChannelSettingsScreen.cpp
@@ -46,12 +46,7 @@ weak_ptr<MpcIndivFxMixerChannel> ChannelSettingsScreen::getIndivFxMixerChannel()
 
 	if (mixerSetupScreen->isIndivFxSourceDrum())
 	{
-		auto padIndex = program.lock()->getPadIndexFromNote(note);
-		
-		if (padIndex == -1)
-			return {};
-		
-		return mpcSoundPlayerChannel->getIndivFxMixerChannels()[padIndex];
+		return mpcSoundPlayerChannel->getIndivFxMixerChannels()[note - 35];
 	}
 	else
 	{
@@ -71,12 +66,7 @@ weak_ptr<MpcStereoMixerChannel> ChannelSettingsScreen::getStereoMixerChannel()
 
 	if (mixerSetupScreen->isStereoMixSourceDrum())
 	{
-		auto padIndex = program.lock()->getPadIndexFromNote(note);
-		
-		if (padIndex == -1)
-			return {};
-		
-		return mpcSoundPlayerChannel->getStereoMixerChannels()[padIndex];
+		return mpcSoundPlayerChannel->getStereoMixerChannels()[note - 35];
 	}
 	else
 	{

--- a/src/main/sampler/Program.hpp
+++ b/src/main/sampler/Program.hpp
@@ -26,8 +26,10 @@ namespace mpc::sampler {
 	public:
 		std::weak_ptr<ctoot::mpc::MpcStereoMixerChannel> getStereoMixerChannel(int noteIndex) override;
 		std::weak_ptr<ctoot::mpc::MpcIndivFxMixerChannel> getIndivFxMixerChannel(int noteIndex) override;
-		int getPadIndexFromNote(int note) override;
-		ctoot::mpc::MpcNoteParameters* getNoteParameters(int i) override;
+        
+		int getPadIndexFromNote(int note);
+		
+        ctoot::mpc::MpcNoteParameters* getNoteParameters(int i) override;
 
 	private:
 		Sampler* sampler = nullptr;


### PR DESCRIPTION
This fixes a crash that happens when we send MIDI notes that are not mapped to a pad to VMPC2000XL. Additionally some refactoring to the `MixerScreen` code has been done.