### PR TITLE
Use getAppConfig instead of getData

### DIFF
--- a/src/main/Paths.cpp
+++ b/src/main/Paths.cpp
@@ -19,7 +19,7 @@ string Paths::appDocumentsPath()
 
 string Paths::appDataPath()
 {
-    static auto path = sago::getData() + sep + "VMPC2000XL" + sep;
+    static auto path = sago::getConfigHome() + sep + "VMPC2000XL" + sep;
     return path;
 }
 


### PR DESCRIPTION
`PlatformFolders.cpp` provides `/Library/Application Support` for `getData`. The application can only write there as root, so we use `getAppConfig` instead, which provides `~/Library/Application Support`.