### PR TITLE
Fixed deleting tracks from the sequence edit screen

### DIFF
--- a/src/main/lcdgui/screens/window/EraseScreen.cpp
+++ b/src/main/lcdgui/screens/window/EraseScreen.cpp
@@ -80,8 +80,8 @@ void EraseScreen::function(int i)
 		break;
 	case 4:
 	{
-		auto startIndex = track - 1;
-		auto lastIndex = track - 1;
+		auto startIndex = track;
+		auto lastIndex = track;
 
 		if (startIndex < 0)
 		{


### PR DESCRIPTION
There is an issue with deleting tracks on the main screen.

### Steps to reproduce:
1. Go to main screen
2. Select track 1
3. Add some events to track 1
4. Select track 2
5. Add some events to track 2
6. Press the "Erase" button
7. Select track 2, press "Do it"
8. See that events were actually erased from track 1 rather than track 2 

### Technical explanation: 
In `EraseScreen.cp` track numbers are handled like they were numbered 1 through 64. However, track numbers already come normalised to 0 though 63 into the method. Doing additional normalisation breaks the logic. 

In case, we enter the value 0 from the screen, which means we want to delete all the tracks in the sequence, the value that is passed to the method is actually `-1`, which is alright since it falls down to the next fork, and gets converted to 0..63 range. 

Thank you



 